### PR TITLE
handle az rotation stops in non-standard positions

### DIFF
--- a/src/gtk-rot-ctrl.c
+++ b/src/gtk-rot-ctrl.c
@@ -100,7 +100,7 @@ static gboolean have_conf(void);
 static gint     sat_name_compare(sat_t * a, sat_t * b);
 static gint     rot_name_compare(const gchar * a, const gchar * b);
 
-static gboolean is_flipped_pass(pass_t * pass, rot_az_type_t type);
+static gboolean is_flipped_pass(pass_t * pass, rot_az_type_t type, gdouble azstoppos);
 static inline void set_flipped_pass(GtkRotCtrl * ctrl);
 
 static GtkVBoxClass *parent_class = NULL;
@@ -985,6 +985,17 @@ static gboolean rot_ctrl_timeout_cb(gpointer data)
                 setaz -= 180;
             else
                 setaz += 180;
+
+            while (setaz > ctrl->conf->maxaz)
+            {
+                setaz -= 360;
+            }
+            while (setaz < ctrl->conf->minaz)
+            {
+                setaz += 360;
+            }
+
+
         }
         if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) && (setaz > 180.0))
         {
@@ -1561,9 +1572,9 @@ static gint rot_name_compare(const gchar * a, const gchar * b)
  *
  * This is a function of the rotator and the particular pass. 
  */
-static gboolean is_flipped_pass(pass_t * pass, rot_az_type_t type)
+static gboolean is_flipped_pass(pass_t * pass, rot_az_type_t type, gdouble azstoppos)
 {
-    gdouble         max_az = 0, min_az = 0;
+    gdouble         max_az = 0, min_az = 0, offset=0;
     gdouble         caz, last_az = pass->aos_az;
     guint           num, i;
     pass_detail_t  *detail;
@@ -1580,7 +1591,17 @@ static gboolean is_flipped_pass(pass_t * pass, rot_az_type_t type)
         min_az = -180;
         max_az = 180;
     }
-
+        
+    /* Offset by (azstoppos-min_az) to handle
+     * rotators with non-default positions.
+     * Note that the default positions of the rotator stops
+     * (eg. -180 for ROT_AZ_TYPE_180, and 0 for 
+     * ROT_AZ_TYPE_360) will create an offset of 0, which
+     * seems like a pretty sane default. */
+    offset = azstoppos-min_az; 
+    min_az += offset;
+    max_az += offset;
+    
     /* Assume that min_az and max_az are atleat 360 degrees apart
        get the azimuth that is in a settable range */
     while (last_az > max_az)
@@ -1598,6 +1619,7 @@ static gboolean is_flipped_pass(pass_t * pass, rot_az_type_t type)
         {
             detail = PASS_DETAIL(g_slist_nth_data(pass->details, i));
             caz = detail->az;
+            
             while (caz > max_az)
             {
                 caz -= 360;
@@ -1606,6 +1628,7 @@ static gboolean is_flipped_pass(pass_t * pass, rot_az_type_t type)
             {
                 caz += 360;
             }
+            
             if (fabs(caz - last_az) > 180)
             {
                 retval = TRUE;
@@ -1627,12 +1650,11 @@ static gboolean is_flipped_pass(pass_t * pass, rot_az_type_t type)
     {
         retval = TRUE;
     }
-
     return retval;
 }
 
 static inline void set_flipped_pass(GtkRotCtrl * ctrl)
 {
     if (ctrl->conf && ctrl->pass)
-        ctrl->flipped = is_flipped_pass(ctrl->pass, ctrl->conf->aztype);
+        ctrl->flipped = is_flipped_pass(ctrl->pass, ctrl->conf->aztype, ctrl->conf->azstoppos);
 }

--- a/src/gtk-rot-ctrl.c
+++ b/src/gtk-rot-ctrl.c
@@ -985,17 +985,17 @@ static gboolean rot_ctrl_timeout_cb(gpointer data)
                 setaz -= 180;
             else
                 setaz += 180;
-
-            while (setaz > ctrl->conf->maxaz)
-            {
-                setaz -= 360;
-            }
-            while (setaz < ctrl->conf->minaz)
-            {
-                setaz += 360;
-            }
-
-
+	    
+	    while (setaz > ctrl->conf->maxaz)
+	    {
+		setaz -= 360;
+	    }
+	    while (setaz < ctrl->conf->minaz)
+	    {
+		setaz += 360;
+	    }
+	    
+	    
         }
         if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) && (setaz > 180.0))
         {

--- a/src/rotor-conf.c
+++ b/src/rotor-conf.c
@@ -44,7 +44,6 @@
 #define KEY_MINEL       "MinEl"
 #define KEY_MAXEL       "MaxEl"
 #define KEY_AZSTOPPOS   "AzStopPos"
-#define KEY_AZSTOPPOSDEFAULT "AzStopPosDefault"
 
 
 /** \brief Read rotator configuration.
@@ -166,25 +165,8 @@ gboolean rotor_conf_read (rotor_conf_t *conf)
         conf->azstoppos = conf->minaz;
     }
     
-    conf->azstopposdefault = g_key_file_get_boolean (cfg, GROUP, KEY_AZSTOPPOSDEFAULT, &error);
-    if (error != NULL) {
-        if (conf->minaz == conf->azstoppos) {
-            sat_log_log (SAT_LOG_LEVEL_WARN,
-                     _("%s: AzStopPosDefault not defined for %s, but AzStopPos matches default for this type, so assuming default."),
-                       __func__, conf->name );
-            conf->azstopposdefault = TRUE;
-            g_clear_error (&error);
-        } else {
-            sat_log_log (SAT_LOG_LEVEL_WARN,
-                     _("%s: AzStopPosDefault not defined for %s, and AzStopPos does not match default for this type, so assuming non-default."),
-                       __func__, conf->name );
-            conf->azstopposdefault = FALSE;
-            g_clear_error (&error);
-        }
-    }
-    
     g_key_file_free (cfg);
-
+    
     return TRUE;
 }
 
@@ -216,7 +198,6 @@ void rotor_conf_save (rotor_conf_t *conf)
     g_key_file_set_double  (cfg, GROUP, KEY_MINEL, conf->minel);
     g_key_file_set_double  (cfg, GROUP, KEY_MAXEL, conf->maxel);
     g_key_file_set_double  (cfg, GROUP, KEY_AZSTOPPOS, conf->azstoppos);
-    g_key_file_set_boolean (cfg, GROUP, KEY_AZSTOPPOSDEFAULT, conf->azstopposdefault);
     
     /* build filename */
     confdir = get_hwconf_dir();

--- a/src/rotor-conf.h
+++ b/src/rotor-conf.h
@@ -48,6 +48,10 @@ typedef struct {
     gdouble      maxaz;     /*!< Upper azimuth limit */
     gdouble      minel;     /*!< Lower elevation limit */
     gdouble      maxel;     /*!< Upper elevation limit */
+    gdouble      azstoppos; /*!< absolute position of rotation stops;
+                             *   will normally be equal to minaz */
+    gboolean     azstopposdefault; /*!< boolean of whethr or not the az stops
+                                    are in the default position */
 } rotor_conf_t;
 
 

--- a/src/rotor-conf.h
+++ b/src/rotor-conf.h
@@ -50,8 +50,6 @@ typedef struct {
     gdouble      maxel;     /*!< Upper elevation limit */
     gdouble      azstoppos; /*!< absolute position of rotation stops;
                              *   will normally be equal to minaz */
-    gboolean     azstopposdefault; /*!< boolean of whethr or not the az stops
-                                    are in the default position */
 } rotor_conf_t;
 
 

--- a/src/sat-pref-rot-data.h
+++ b/src/sat-pref-rot-data.h
@@ -38,6 +38,12 @@ typedef enum {
     ROT_LIST_COL_MINEL,     /*!< Lower El limit. */
     ROT_LIST_COL_MAXEL,     /*!< Upper El limit. */
     ROT_LIST_COL_AZTYPE,    /*!< Azimuth type. */
+    ROT_LIST_COL_AZSTOPPOS, /*!< Position of the azimuth rotation stops.
+                                 Should default to MINAZ, unless specified
+                                 otherwise */
+    ROT_LIST_COL_AZSTOPPOSDEFAULT, /*!< Boolean of whether or not the AZSTOPPOS
+                                        supposed to be the default for this rotor
+                                        type */
     ROT_LIST_COL_NUM        /*!< The number of fields in the list. */
 } rotor_list_col_t;
 

--- a/src/sat-pref-rot-data.h
+++ b/src/sat-pref-rot-data.h
@@ -41,9 +41,6 @@ typedef enum {
     ROT_LIST_COL_AZSTOPPOS, /*!< Position of the azimuth rotation stops.
                                  Should default to MINAZ, unless specified
                                  otherwise */
-    ROT_LIST_COL_AZSTOPPOSDEFAULT, /*!< Boolean of whether or not the AZSTOPPOS
-                                        supposed to be the default for this rotor
-                                        type */
     ROT_LIST_COL_NUM        /*!< The number of fields in the list. */
 } rotor_list_col_t;
 

--- a/src/sat-pref-rot-editor.c
+++ b/src/sat-pref-rot-editor.c
@@ -60,7 +60,7 @@ static GtkWidget *maxaz;
 static GtkWidget *minel;
 static GtkWidget *maxel;
 static GtkWidget *azstoppos;
-static GtkWidget *azstopposdefault;
+
 
 static GtkWidget    *create_editor_widgets (rotor_conf_t *conf);
 static void          update_widgets        (rotor_conf_t *conf);
@@ -68,8 +68,6 @@ static void          clear_widgets         (void);
 static gboolean      apply_changes         (rotor_conf_t *conf);
 static void          name_changed          (GtkWidget *widget, gpointer data);
 static void          aztype_changed_cb     (GtkComboBox *box, gpointer data);
-static void          azstoppos_toggled    (GtkCheckButton *button, gpointer data);
-
 
 
 /** \brief Add or edit a rotor configuration.
@@ -254,33 +252,19 @@ create_editor_widgets (rotor_conf_t *conf)
     gtk_spin_button_set_numeric (GTK_SPIN_BUTTON (maxel), TRUE);
     gtk_spin_button_set_wrap (GTK_SPIN_BUTTON (maxel), FALSE);
     gtk_table_attach_defaults (GTK_TABLE (table), maxel, 3, 4, 6, 7);
-
-    gtk_table_attach_defaults (GTK_TABLE (table), gtk_hseparator_new(), 0, 4, 7, 8);
-
+    
+    
     
     label = gtk_label_new (_(" Azimuth Rotation Stop Position"));
-    gtk_table_attach_defaults (GTK_TABLE (table), label, 0, 4, 8, 9);
-    
-
-
-    label = gtk_label_new (_(" Custom Stop Position"));
     gtk_misc_set_alignment (GTK_MISC (label), 1.0, 0.5);
-    gtk_table_attach_defaults (GTK_TABLE (table), label, 0, 2, 10, 11);
+    gtk_table_attach_defaults (GTK_TABLE (table), label, 1, 3, 7, 8);
     azstoppos = gtk_spin_button_new_with_range (-180, 360, 1);
-    gtk_spin_button_set_value (GTK_SPIN_BUTTON (azstoppos), 0);
+    gtk_spin_button_set_value (GTK_SPIN_BUTTON (azstoppos), 90);
     gtk_spin_button_set_numeric (GTK_SPIN_BUTTON (azstoppos), TRUE);
     gtk_spin_button_set_wrap (GTK_SPIN_BUTTON (azstoppos), FALSE);
-    gtk_widget_set_sensitive(azstoppos, FALSE);
-    gtk_table_attach_defaults (GTK_TABLE (table), azstoppos, 2, 4, 10, 11);
+    gtk_table_attach_defaults (GTK_TABLE (table), azstoppos, 3, 4, 7, 8);
     
-
-    label = gtk_label_new (_(" Use Default for Az Type"));
-    gtk_misc_set_alignment (GTK_MISC (label), 1.0, 0.5);
-    gtk_table_attach_defaults (GTK_TABLE (table), label, 0, 2, 9, 10);
-    azstopposdefault = gtk_check_button_new();
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(azstopposdefault), TRUE);
-    g_signal_connect (G_OBJECT (azstopposdefault), "toggled", G_CALLBACK (azstoppos_toggled), NULL);
-    gtk_table_attach_defaults (GTK_TABLE (table), azstopposdefault, 2, 4, 9, 10);
+    
     
     
     
@@ -320,7 +304,6 @@ update_widgets (rotor_conf_t *conf)
     gtk_spin_button_set_value (GTK_SPIN_BUTTON (minel), conf->minel);
     gtk_spin_button_set_value (GTK_SPIN_BUTTON (maxel), conf->maxel);
     gtk_spin_button_set_value (GTK_SPIN_BUTTON (azstoppos), conf->azstoppos);
-    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (azstopposdefault), conf->azstopposdefault);
     
 
 }
@@ -344,7 +327,6 @@ clear_widgets ()
     gtk_spin_button_set_value (GTK_SPIN_BUTTON (minel), 0);
     gtk_spin_button_set_value (GTK_SPIN_BUTTON (maxel), 90);
     gtk_spin_button_set_value (GTK_SPIN_BUTTON (azstoppos), 0);
-    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (azstopposdefault), TRUE);
     
 }
 
@@ -385,9 +367,6 @@ apply_changes         (rotor_conf_t *conf)
 
     /* az stop position */
     conf->azstoppos = gtk_spin_button_get_value (GTK_SPIN_BUTTON (azstoppos));
-    
-    /* az stop position is/isn't default */
-    conf->azstopposdefault = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (azstopposdefault));
     
      return TRUE;
 }
@@ -465,18 +444,12 @@ static void aztype_changed_cb     (GtkComboBox *box, gpointer data)
         case ROT_AZ_TYPE_360:
             gtk_spin_button_set_value (GTK_SPIN_BUTTON (minaz), 0.0);
             gtk_spin_button_set_value (GTK_SPIN_BUTTON (maxaz), 360.0);
-	    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(azstopposdefault))) {
-	     gtk_spin_button_set_value (GTK_SPIN_BUTTON (azstoppos), 0.0);
-	    }
             break;
             
         case ROT_AZ_TYPE_180:
             gtk_spin_button_set_value (GTK_SPIN_BUTTON (minaz), -180.0);
             gtk_spin_button_set_value (GTK_SPIN_BUTTON (maxaz), +180.0);
-	    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(azstopposdefault))) {
-	     gtk_spin_button_set_value (GTK_SPIN_BUTTON (azstoppos), -180.0);
-	    }
-	    break;
+            break;
             
         default:
             sat_log_log (SAT_LOG_LEVEL_ERROR,
@@ -485,22 +458,4 @@ static void aztype_changed_cb     (GtkComboBox *box, gpointer data)
             break;
     }
 
-}
-
-static void azstoppos_toggled    (GtkCheckButton *button, gpointer data)
-{
- 
-     
-    
-    (void) data; /* avoid unused parameter compiler warning */
-  
-  
-    if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button))) {
-      gtk_widget_set_sensitive(azstoppos, FALSE);
-      gtk_spin_button_set_value (GTK_SPIN_BUTTON (azstoppos), gtk_spin_button_get_value( GTK_SPIN_BUTTON (minaz)));
-      
-    } else {
-      gtk_widget_set_sensitive(azstoppos, TRUE);
-    }
-  
 }

--- a/src/sat-pref-rot-editor.c
+++ b/src/sat-pref-rot-editor.c
@@ -259,9 +259,15 @@ create_editor_widgets (rotor_conf_t *conf)
     gtk_misc_set_alignment (GTK_MISC (label), 1.0, 0.5);
     gtk_table_attach_defaults (GTK_TABLE (table), label, 1, 3, 7, 8);
     azstoppos = gtk_spin_button_new_with_range (-180, 360, 1);
-    gtk_spin_button_set_value (GTK_SPIN_BUTTON (azstoppos), 90);
+    gtk_spin_button_set_value (GTK_SPIN_BUTTON (azstoppos), 0);
     gtk_spin_button_set_numeric (GTK_SPIN_BUTTON (azstoppos), TRUE);
     gtk_spin_button_set_wrap (GTK_SPIN_BUTTON (azstoppos), FALSE);
+    gtk_widget_set_tooltip_text (azstoppos,
+                                 _("Set the position of the azimuth rotation stops here, where "
+                                  "0\302\260 is at North, -180\302\260 is south, etc. "
+				  "The default for a 0\302\260 \342\206\222 180\302\260 \342\206\222 360\302\260 rotor is 0\302\260, and the default for a "\
+                                  "-180\302\260 \342\206\222 0\302\260 \342\206\222 +180\302\260 rotor "
+				  "is -180\302\260."));
     gtk_table_attach_defaults (GTK_TABLE (table), azstoppos, 3, 4, 7, 8);
     
     
@@ -444,12 +450,14 @@ static void aztype_changed_cb     (GtkComboBox *box, gpointer data)
         case ROT_AZ_TYPE_360:
             gtk_spin_button_set_value (GTK_SPIN_BUTTON (minaz), 0.0);
             gtk_spin_button_set_value (GTK_SPIN_BUTTON (maxaz), 360.0);
+	    gtk_spin_button_set_value (GTK_SPIN_BUTTON (azstoppos), 0.0);
             break;
             
         case ROT_AZ_TYPE_180:
             gtk_spin_button_set_value (GTK_SPIN_BUTTON (minaz), -180.0);
             gtk_spin_button_set_value (GTK_SPIN_BUTTON (maxaz), +180.0);
-            break;
+            gtk_spin_button_set_value (GTK_SPIN_BUTTON (azstoppos), -180.0);
+	    break;
             
         default:
             sat_log_log (SAT_LOG_LEVEL_ERROR,

--- a/src/sat-pref-rot.c
+++ b/src/sat-pref-rot.c
@@ -445,7 +445,7 @@ static void add_cb    (GtkWidget *button, gpointer data)
         .minel = 0,
         .maxel = 90,
         .aztype = ROT_AZ_TYPE_360,
-        .azstoppos = 45,
+        .azstoppos = 0,
     };
     
     /* run rot conf editor */

--- a/src/sat-pref-rot.c
+++ b/src/sat-pref-rot.c
@@ -191,6 +191,7 @@ static void create_rot_list ()
     gtk_tree_view_insert_column (GTK_TREE_VIEW (rotlist), column, -1);
 
     g_signal_connect (rotlist, "row-activated", G_CALLBACK (row_activated_cb), NULL);
+
 }
 
 
@@ -215,7 +216,9 @@ static GtkTreeModel *create_and_fill_model ()
                                     G_TYPE_DOUBLE,    // Max Az
                                     G_TYPE_DOUBLE,    // Min El
                                     G_TYPE_DOUBLE,    // Max El
-                                    G_TYPE_INT        // Az type
+                                    G_TYPE_INT,       // Az type
+                                    G_TYPE_DOUBLE,    // Az Stop Position
+                                    G_TYPE_BOOLEAN    // Az Stop Position is default for type
                                    );
      gtk_tree_sortable_set_sort_column_id( GTK_TREE_SORTABLE(liststore),ROT_LIST_COL_NAME,GTK_SORT_ASCENDING);
     /* open configuration directory */
@@ -243,6 +246,8 @@ static GtkTreeModel *create_and_fill_model ()
                                         ROT_LIST_COL_MINEL, conf.minel,
                                         ROT_LIST_COL_MAXEL, conf.maxel,
                                         ROT_LIST_COL_AZTYPE, conf.aztype,
+                                        ROT_LIST_COL_AZSTOPPOS, conf.azstoppos,
+                                        ROT_LIST_COL_AZSTOPPOSDEFAULT, conf.azstopposdefault,
                                         -1);
                     
                     sat_log_log (SAT_LOG_LEVEL_DEBUG,
@@ -355,6 +360,8 @@ void sat_pref_rot_ok     ()
         .minel = 0,
         .maxel = 90,
         .aztype = ROT_AZ_TYPE_360,
+        .azstoppos = 0,
+        .azstopposdefault = TRUE,
     };
 
     
@@ -396,6 +403,8 @@ void sat_pref_rot_ok     ()
                                 ROT_LIST_COL_MINEL, &conf.minel,
                                 ROT_LIST_COL_MAXEL, &conf.maxel,
                                 ROT_LIST_COL_AZTYPE, &conf.aztype,
+                                ROT_LIST_COL_AZSTOPPOS, &conf.azstoppos,
+                                ROT_LIST_COL_AZSTOPPOSDEFAULT, &conf.azstopposdefault,
                                 -1);
             rotor_conf_save (&conf);
         
@@ -440,6 +449,8 @@ static void add_cb    (GtkWidget *button, gpointer data)
         .minel = 0,
         .maxel = 90,
         .aztype = ROT_AZ_TYPE_360,
+        .azstoppos = 0,
+	.azstopposdefault = TRUE,
     };
     
     /* run rot conf editor */
@@ -458,6 +469,8 @@ static void add_cb    (GtkWidget *button, gpointer data)
                             ROT_LIST_COL_MINEL, conf.minel,
                             ROT_LIST_COL_MAXEL, conf.maxel,
                             ROT_LIST_COL_AZTYPE, conf.aztype,
+                            ROT_LIST_COL_AZSTOPPOS, conf.azstoppos,
+                            ROT_LIST_COL_AZSTOPPOSDEFAULT, conf.azstopposdefault,
                             -1);
         
         g_free (conf.name);
@@ -495,6 +508,8 @@ static void edit_cb   (GtkWidget *button, gpointer data)
         .minel = 0,
         .maxel = 90,
         .aztype = ROT_AZ_TYPE_360,
+        .azstoppos = 0, //used in the "new rotator" dialog
+	.azstopposdefault = TRUE,
     };
 
     
@@ -524,6 +539,8 @@ static void edit_cb   (GtkWidget *button, gpointer data)
                             ROT_LIST_COL_MINEL, &conf.minel,
                             ROT_LIST_COL_MAXEL, &conf.maxel,
                             ROT_LIST_COL_AZTYPE, &conf.aztype,
+                            ROT_LIST_COL_AZSTOPPOS, &conf.azstoppos,
+                            ROT_LIST_COL_AZSTOPPOSDEFAULT, &conf.azstopposdefault,
                             -1);
 
     }
@@ -556,6 +573,8 @@ static void edit_cb   (GtkWidget *button, gpointer data)
                             ROT_LIST_COL_MINEL, conf.minel,
                             ROT_LIST_COL_MAXEL, conf.maxel,
                             ROT_LIST_COL_AZTYPE, conf.aztype,
+                            ROT_LIST_COL_AZSTOPPOS, conf.azstoppos,
+                            ROT_LIST_COL_AZSTOPPOSDEFAULT, conf.azstopposdefault,
                             -1);
         
     }

--- a/src/sat-pref-rot.c
+++ b/src/sat-pref-rot.c
@@ -217,8 +217,7 @@ static GtkTreeModel *create_and_fill_model ()
                                     G_TYPE_DOUBLE,    // Min El
                                     G_TYPE_DOUBLE,    // Max El
                                     G_TYPE_INT,       // Az type
-                                    G_TYPE_DOUBLE,    // Az Stop Position
-                                    G_TYPE_BOOLEAN    // Az Stop Position is default for type
+                                    G_TYPE_DOUBLE     // Az Stop Position
                                    );
      gtk_tree_sortable_set_sort_column_id( GTK_TREE_SORTABLE(liststore),ROT_LIST_COL_NAME,GTK_SORT_ASCENDING);
     /* open configuration directory */
@@ -247,7 +246,6 @@ static GtkTreeModel *create_and_fill_model ()
                                         ROT_LIST_COL_MAXEL, conf.maxel,
                                         ROT_LIST_COL_AZTYPE, conf.aztype,
                                         ROT_LIST_COL_AZSTOPPOS, conf.azstoppos,
-                                        ROT_LIST_COL_AZSTOPPOSDEFAULT, conf.azstopposdefault,
                                         -1);
                     
                     sat_log_log (SAT_LOG_LEVEL_DEBUG,
@@ -361,7 +359,6 @@ void sat_pref_rot_ok     ()
         .maxel = 90,
         .aztype = ROT_AZ_TYPE_360,
         .azstoppos = 0,
-        .azstopposdefault = TRUE,
     };
 
     
@@ -404,7 +401,6 @@ void sat_pref_rot_ok     ()
                                 ROT_LIST_COL_MAXEL, &conf.maxel,
                                 ROT_LIST_COL_AZTYPE, &conf.aztype,
                                 ROT_LIST_COL_AZSTOPPOS, &conf.azstoppos,
-                                ROT_LIST_COL_AZSTOPPOSDEFAULT, &conf.azstopposdefault,
                                 -1);
             rotor_conf_save (&conf);
         
@@ -449,8 +445,7 @@ static void add_cb    (GtkWidget *button, gpointer data)
         .minel = 0,
         .maxel = 90,
         .aztype = ROT_AZ_TYPE_360,
-        .azstoppos = 0,
-	.azstopposdefault = TRUE,
+        .azstoppos = 45,
     };
     
     /* run rot conf editor */
@@ -470,7 +465,6 @@ static void add_cb    (GtkWidget *button, gpointer data)
                             ROT_LIST_COL_MAXEL, conf.maxel,
                             ROT_LIST_COL_AZTYPE, conf.aztype,
                             ROT_LIST_COL_AZSTOPPOS, conf.azstoppos,
-                            ROT_LIST_COL_AZSTOPPOSDEFAULT, conf.azstopposdefault,
                             -1);
         
         g_free (conf.name);
@@ -509,7 +503,6 @@ static void edit_cb   (GtkWidget *button, gpointer data)
         .maxel = 90,
         .aztype = ROT_AZ_TYPE_360,
         .azstoppos = 0, //used in the "new rotator" dialog
-	.azstopposdefault = TRUE,
     };
 
     
@@ -540,7 +533,6 @@ static void edit_cb   (GtkWidget *button, gpointer data)
                             ROT_LIST_COL_MAXEL, &conf.maxel,
                             ROT_LIST_COL_AZTYPE, &conf.aztype,
                             ROT_LIST_COL_AZSTOPPOS, &conf.azstoppos,
-                            ROT_LIST_COL_AZSTOPPOSDEFAULT, &conf.azstopposdefault,
                             -1);
 
     }
@@ -574,7 +566,6 @@ static void edit_cb   (GtkWidget *button, gpointer data)
                             ROT_LIST_COL_MAXEL, conf.maxel,
                             ROT_LIST_COL_AZTYPE, conf.aztype,
                             ROT_LIST_COL_AZSTOPPOS, conf.azstoppos,
-                            ROT_LIST_COL_AZSTOPPOSDEFAULT, conf.azstopposdefault,
                             -1);
         
     }


### PR DESCRIPTION
This code should handle the azimuth rotation stops in non-default positions.  Feel free to change the look of the GUI components, if needed, though I hope they're fairly intuitive. - Lloyd