### PR TITLE
visual improvements on the transponder page of sat-info, 

### DIFF
--- a/src/frq-update.c
+++ b/src/frq-update.c
@@ -250,13 +250,13 @@ void frq_update_files(gchar * frqfile)
                     //sat_log_log(SAT_LOG_LEVEL_DEBUG, _("downlink_high : %Ld"),m_trsp.downlink_high, __func__);
                     //sat_log_log(SAT_LOG_LEVEL_DEBUG, _("         Mode : %s"), m_trsp.mode, __func__);
                     //sat_log_log(SAT_LOG_LEVEL_DEBUG, _("       Invert : %s"), m_trsp.invert ? "true" : "false", __func__);
-                    //sat_log_log(SAT_LOG_LEVEL_DEBUG, _("         Baud : %lf"),m_trsp.baud, __func__);
+                    // sat_log_log(SAT_LOG_LEVEL_DEBUG, _("         Baud : %lf"),m_trsp.baud, __func__);
                     //sat_log_log(SAT_LOG_LEVEL_DEBUG, _(" norad_cat_id : %Ld"),m_trsp.catnum, __func__);
                     char            m_catnum[20];
 
                     sprintf(m_catnum, "%d", m_trsp.catnum);
                     trspfile = g_strconcat(trspfolder, G_DIR_SEPARATOR_S, m_catnum,".trsp", NULL);
-                    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s: Writing to file : %s "), __func__, trspfile);
+                    //sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s: Writing to file : %s "), __func__, trspfile);
 
                     //first lets delete the file we already have, to make space for the new version
                     /* check existence and add data to hash table for future check */
@@ -292,14 +292,8 @@ void frq_update_files(gchar * frqfile)
                         sprintf(fcontent, "%sUP_HIGH=%d\n", fcontent, m_trsp.uplink_high);
                         sprintf(fcontent, "%sDOWN_LOW=%d\n", fcontent, m_trsp.downlink_low);
                         sprintf(fcontent, "%sDOWN_HIGH=%d\n", fcontent, m_trsp.downlink_high);
-                        if (m_trsp.baud!=0)
-			{
-				sprintf(fcontent, "%sMODE=%s baud: %9.2f\n", fcontent, m_trsp.mode, m_trsp.baud);
-			}
-			else
-			{
-				sprintf(fcontent, "%sMODE= %s\n",fcontent,m_trsp.mode);
-			}
+			sprintf(fcontent, "%sMODE= %s\n",fcontent,m_trsp.mode);
+			sprintf(fcontent, "%sBAUD= %9.2f\n", fcontent, m_trsp.baud);
 			sprintf(fcontent, "%sINVERT=%s\n\n", fcontent, m_trsp.invert ? "true" : "false");
 
                         fputs(fcontent, ffile);

--- a/src/frq-update.c
+++ b/src/frq-update.c
@@ -292,8 +292,15 @@ void frq_update_files(gchar * frqfile)
                         sprintf(fcontent, "%sUP_HIGH=%d\n", fcontent, m_trsp.uplink_high);
                         sprintf(fcontent, "%sDOWN_LOW=%d\n", fcontent, m_trsp.downlink_low);
                         sprintf(fcontent, "%sDOWN_HIGH=%d\n", fcontent, m_trsp.downlink_high);
-                        sprintf(fcontent, "%sMODE=%s baud:%f\n", fcontent, m_trsp.mode, m_trsp.baud);
-                        sprintf(fcontent, "%sINVERT=%s\n\n", fcontent, m_trsp.invert ? "true" : "false");
+                        if (m_trsp.baud!=0)
+			{
+				sprintf(fcontent, "%sMODE=%s baud: %9.2f\n", fcontent, m_trsp.mode, m_trsp.baud);
+			}
+			else
+			{
+				sprintf(fcontent, "%sMODE= %s\n",fcontent,m_trsp.mode);
+			}
+			sprintf(fcontent, "%sINVERT=%s\n\n", fcontent, m_trsp.invert ? "true" : "false");
 
                         fputs(fcontent, ffile);
                         fclose(ffile);

--- a/src/sat-info.c
+++ b/src/sat-info.c
@@ -505,6 +505,13 @@ static GtkWidget *create_transponder_table (guint catnum)
                 g_free (text);
                 gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
             }
+	    if (trsp->baud) {
+                text = g_strdup_printf (_("Baudrate: %9.2f"), trsp->baud);
+                label = gtk_label_new (text);
+                gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
+                g_free (text);
+                gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
+            }
         }
         free_transponders (trsplist);
 

--- a/src/trsp-conf.c
+++ b/src/trsp-conf.c
@@ -39,6 +39,7 @@
 #define KEY_DOWN_HIGH   "DOWN_HIGH"
 #define KEY_INVERT      "INVERT"
 #define KEY_MODE        "MODE"
+#define KEY_BAUD	"BAUD"
 
 /**
  * Read transponder data file.
@@ -124,7 +125,7 @@ GSList         *read_transponders(guint catnum)
                                               KEY_DOWN_LOW, &error);
         if (error != NULL)
         {
-            sat_log_log(SAT_LOG_LEVEL_INFO, INFO_MSG, __func__, KEY_UP_HIGH,
+            sat_log_log(SAT_LOG_LEVEL_INFO, INFO_MSG, __func__, KEY_DOWN_LOW,
                         name, groups[i]);
             g_clear_error(&error);
             trsp->downlow = 0.0;
@@ -144,7 +145,7 @@ GSList         *read_transponders(guint catnum)
                                               KEY_INVERT, &error);
         if (error != NULL)
         {
-            sat_log_log(SAT_LOG_LEVEL_INFO, INFO_MSG, __func__, KEY_DOWN_HIGH,
+            sat_log_log(SAT_LOG_LEVEL_INFO, INFO_MSG, __func__, KEY_INVERT,
                         name, groups[i]);
             g_clear_error(&error);
             trsp->invert = FALSE;
@@ -154,10 +155,20 @@ GSList         *read_transponders(guint catnum)
                                            KEY_MODE, &error);
         if (error != NULL)
         {
-            sat_log_log(SAT_LOG_LEVEL_INFO, INFO_MSG, __func__, KEY_DOWN_HIGH,
+            sat_log_log(SAT_LOG_LEVEL_INFO, INFO_MSG, __func__, KEY_MODE,
                         name, groups[i]);
             g_clear_error(&error);
         }
+	
+	trsp->baud = g_key_file_get_double(cfg, groups[i],
+                                           KEY_BAUD, &error);
+        if (error != NULL)
+        {
+            sat_log_log(SAT_LOG_LEVEL_INFO, INFO_MSG, __func__, KEY_BAUD,
+                        name, groups[i]);
+            g_clear_error(&error);
+        }
+
 
         /* add transponder to list */
         trsplist = g_slist_append(trsplist, trsp);

--- a/src/trsp-conf.h
+++ b/src/trsp-conf.h
@@ -36,9 +36,10 @@ typedef struct {
     gdouble         uphigh;     /*!< Upper limit of uplink. */
     gdouble         downlow;    /*!< Lower limit of downlink. */
     gdouble         downhigh;   /*!< Upper limit of donlink. */
+    gdouble	    baud;	/*!< Baud rate > */
     gboolean        invert;     /*!< Flag indicating whether transponder is inverting. */
     gchar          *mode;       /*!< Mode descriptor. */
-} trsp_t;
+ } trsp_t;
 
 /* The actual data would then be a singly linked list with pointers to transponder_t structures */
 


### PR DESCRIPTION
show baud-rate only if not 0,
show only  2 decimals on baudrate.

@csete this may be improved further together with the modes,
The debugging info shows many  different modes which are basically one mode and different data rates (e.g. AFSK1k2&AFSK9k6)
But maybe  this is also outside the scope of gpredict and should be adressed at the source of the data not at the sink of the data
