### PR TITLE
Corrected orbit number

### DIFF
--- a/src/gtk-sat-data.c
+++ b/src/gtk-sat-data.c
@@ -5,6 +5,7 @@
   Copyright (C)  2001-2009  Alexandru Csete, OZ9AEC.
 
   Authors: Alexandru Csete <oz9aec@gmail.com>
+           Daniel Estevez <daniel@destevez.net>
 
   Comments, questions and bugreports should be submitted via
   http://sourceforge.net/projects/gpredict/
@@ -242,8 +243,8 @@ gtk_sat_data_init_sat (sat_t *sat, qth_t *qth)
     sat->footprint = 2.0 * xkmper * acos (xkmper/sat->pos.w);
     age = 0.0;
     sat->orbit = (long) floor((sat->tle.xno * xmnpda/twopi +
-                               age * sat->tle.bstar * ae) * age +
-                              sat->tle.xmo/twopi) + sat->tle.revnum - 1;
+                               age * sat->tle.bstar * ae) * age -
+                              (sat->tle.xmo + sat->tle.omegao)/twopi) + sat->tle.revnum;
 
     /* orbit type */
     sat->otype = get_orbit_type (sat);

--- a/src/predict-tools.c
+++ b/src/predict-tools.c
@@ -7,6 +7,7 @@
     Authors: Alexandru Csete <oz9aec@gmail.com>
              John A. Magliacane, KD2BD.
              Charles Suprin <hamaa1vs@gmail.com>
+	     Daniel Estevez <daniel@destevez.net>
 
     Comments, questions and bugreports should be submitted via
     http://sourceforge.net/projects/gpredict/
@@ -104,7 +105,7 @@ void predict_calc(sat_t * sat, qth_t * qth, gdouble t)
     age = sat->jul_utc - sat->jul_epoch;
     sat->orbit = (long)floor((sat->tle.xno * xmnpda / twopi +
                               age * sat->tle.bstar * ae) * age +
-                             sat->tle.xmo / twopi) + sat->tle.revnum - 1;
+                             (sat->tle.xmo + sat->tle.omegao) / twopi) + sat->tle.revnum ;
 }
 
 /**


### PR DESCRIPTION
The orbit number should change at the ascending node according to the TLE specifications. With the current calculation, it changed at the perigee.

The following is from [CelesTrak](https://celestrak.com/columns/v04n03/):

> In NORAD's convention, a revolution begins when the satellite is at the ascending node of its orbit and a revolution is the period between successive ascending nodes. The period from launch to the first ascending node is considered to be Rev 0 and Rev 1 begins when the first ascending node is reached. Since many element sets are generated with epochs that place the satellite near its ascending node, it is important to note whether the satellite has reached the ascending node when calculating subsequent rev numbers.

This calculation of when the satellite crosses the ascending node is not extremely precise, probably due to some issue with the Bstar coefficient, but it is OK for most uses.