### PR TITLE
Multithread ctrl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ mkinstalldirs
 libtool
 goocanvas
 m4/
+*~

--- a/doc/notes/ft-847.txt
+++ b/doc/notes/ft-847.txt
@@ -2,9 +2,15 @@ Setting up gpredict for use with a Yaesu FT-847 radio
 
 As an USB to RS232 interface I bought the converter from "TechnoFix UK",
 which can be obtained from e.g. ebay et al.
+There might be a problem with your braille kernel driver, so you have
+to disable this from loading at system start (to get /dev/ttyUSB?).
+Remember to add the user running rigtcl[d] to the dialout group.
 My PC is running an actual debian with KDE as desktop environment and
 hamlib is the version delivered as distri package (currently
 Hamlib 1.2.15.3), because I have been too lazy to compile it by myself.
+Another issue I found while testing the threaded version of my gpredict
+build: transponder modes, such as FM, LSB, USB etc. have to be set
+manual on the radio.
 
 FT-847:
 Menu 37 "CAT RATE" -> 57600

--- a/doc/notes/ft-847.txt
+++ b/doc/notes/ft-847.txt
@@ -1,7 +1,16 @@
 Setting up gpredict for use with a Yaesu FT-847 radio
 
+As an USB to RS232 interface I bought the converter from "TechnoFix UK",
+which can be obtained from e.g. ebay et al.
+My PC is running an actual debian with KDE as desktop environment and
+hamlib is the version delivered as distri package (currently
+Hamlib 1.2.15.3), because I have been too lazy to compile it by myself.
+
 FT-847:
 Menu 37 "CAT RATE" -> 57600
+
+rigctld:
+/usr/bin/rigctld -m 101 -r /dev/ttyUSB0 -t 4532 -s 57600 --set-conf=stop_bits=2,serial_handshake=None
 
 gpredict:
 Edit -> Preferences -> Interfaces -> Add New
@@ -15,9 +24,6 @@ Edit -> Preferences -> Interfaces -> Add New
   LO Up: <used with upconverter>
   Signalling: [ ] AOS      [ ] LOS
 
-rigctld:
-/usr/bin/rigctld -m 101 -r /dev/ttyUSB0 -t 4532 -s 57600 --set-conf=stop_bits=2,serial_handshake=None
-
 in Radiocontrol widget:
 Settings:
   1. Device: YAESUFT-847
@@ -26,15 +32,22 @@ Settings:
 
 Note on Cycle:
 You have to chose a value bigger than the communication via RS232 to
-the radio takes! This is approximately 300 ms per command. With a
+the radio takes! This is approximately 300 ms per command, existing of
+the command itself and the answer, containing the result. With a
 full-duplex radio there are 7 (!) commands executed: 1. [t] get PTT
 status, 2. [f] get current VFOA frq, 3. [F {...}] set new VFOA frq,
 4. [f] check if new VFOA frq is set, 5. [i] get current SUB frq,
-6. [I {...] set new SUB frq, 7. [i] check if new SUB frq is set. This
+6. [I {...}] set new SUB frq, 7. [i] check if new SUB frq is set. This
 results in a cycle-time of approx 2100 ms - add some time to ensure all
-commands are transmitted.
+commands are transmitted. The idea to enclose the whole communication
+into separate threads came up, because socket communication is always
+blocking. This also comes up with rotcld! Still some work to do...
 
 One full cycle:
 2017-03-02 19:24:18.918677
 t f F {...} f i I {...} i
 2017-03-02 19:24:21.036607
+
+(to be enhanced...)
+
+Mar. 2017, Patrick Dohmen (DL4PD)

--- a/doc/notes/ft-847.txt
+++ b/doc/notes/ft-847.txt
@@ -1,0 +1,40 @@
+Setting up gpredict for use with a Yaesu FT-847 radio
+
+FT-847:
+Menu 37 "CAT RATE" -> 57600
+
+gpredict:
+Edit -> Preferences -> Interfaces -> Add New
+  Name: YAESUFT-847
+  Host: 127.0.0.1
+  Port: 4532
+  Radio Type: Duplex TRX
+  PTT status: Read PTT
+  VFO Up/Down: SUB /\ / MAIN \/
+  LO Down: <used with downconverter>
+  LO Up: <used with upconverter>
+  Signalling: [ ] AOS      [ ] LOS
+
+rigctld:
+/usr/bin/rigctld -m 101 -r /dev/ttyUSB0 -t 4532 -s 57600 --set-conf=stop_bits=2,serial_handshake=None
+
+in Radiocontrol widget:
+Settings:
+  1. Device: YAESUFT-847
+  2. Device: None
+  Cycle: 2500
+
+Note on Cycle:
+You have to chose a value bigger than the communication via RS232 to
+the radio takes! This is approximately 300 ms per command. With a
+full-duplex radio there are 7 (!) commands executed: 1. [t] get PTT
+status, 2. [f] get current VFOA frq, 3. [F {...}] set new VFOA frq,
+4. [f] check if new VFOA frq is set, 5. [i] get current SUB frq,
+6. [I {...] set new SUB frq, 7. [i] check if new SUB frq is set. This
+results in a cycle-time of approx 2100 ms - add some time to ensure all
+commands are transmitted.
+
+One full cycle:
+2017-03-02 19:24:18.918677
+t f F {...} f i I {...} i
+2017-03-02 19:24:21.036607

--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -146,7 +146,6 @@ static gint     sat_name_compare(sat_t * a, sat_t * b);
 static gint     rig_name_compare(const gchar * a, const gchar * b);
 
 
-<<<<<<< HEAD
 
 /* DL4PD: add thread for hamlib communication */
 gpointer        rigctl_run(gpointer data);
@@ -159,24 +158,11 @@ static void     start_timer(GtkRigCtrl * data);
 
 
 static GtkVBoxClass *parent_class = NULL;
-=======
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
 
-/* DL4PD: add thread for hamlib communication */
-gpointer        rigctl_run( gpointer data );
-static void     rigctrl_open(GtkRigCtrl * data);
-static void     rigctrl_close(GtkRigCtrl * data);
-static void     setconfig(gpointer data);
-static void     remove_timer(GtkRigCtrl * data);
-static void     start_timer(GtkRigCtrl * data);
-
-
-G_LOCK_DEFINE_STATIC(writelock);
-G_LOCK_DEFINE_STATIC(rig_ctrl_updatelock);
-
-
-
-static GtkVBoxClass *parent_class = NULL;
+static GdkColor ColBlack = { 0, 0, 0, 0 };
+static GdkColor ColWhite = { 0, 0xFFFF, 0xFFFF, 0xFFFF };
+static GdkColor ColRed = { 0, 0xFFFF, 0, 0 };
+static GdkColor ColGreen = { 0, 0, 0xFFFF, 0 };
 
 
 GType gtk_rig_ctrl_get_type()
@@ -330,6 +316,11 @@ GtkWidget      *gtk_rig_ctrl_new(GtkSatModule * module)
             get_next_pass(GTK_RIG_CTRL(widget)->target,
                           GTK_RIG_CTRL(widget)->qth, 3.0);
     }
+    /* initialise custom colors */
+    gdk_rgb_find_color(gtk_widget_get_colormap(widget), &ColBlack);
+    gdk_rgb_find_color(gtk_widget_get_colormap(widget), &ColWhite);
+    gdk_rgb_find_color(gtk_widget_get_colormap(widget), &ColRed);
+    gdk_rgb_find_color(gtk_widget_get_colormap(widget), &ColGreen);
 
     /* create contents */
     table = gtk_table_new(3, 2, FALSE);
@@ -1354,7 +1345,7 @@ static void rig_engaged_cb(GtkToggleButton * button, gpointer data)
 static gboolean setup_split(GtkRigCtrl * ctrl)
 {
     gchar          *buff;
-    gchar           buffback[256/*128*/]; /* DL4PD: issues with receiving rigctld answer (assertion failed) */
+    gchar           buffback[128];
     gboolean        retcode;
 
     /* select TX VFO */
@@ -2233,11 +2224,7 @@ static gboolean get_ptt(GtkRigCtrl * ctrl, gint sock)
             pttstat = g_ascii_strtoull(vbuff[0], NULL, 0);      //FIXME base = 0 ok?
         g_strfreev(vbuff);
     }
-<<<<<<< HEAD
 
-=======
-    
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
     g_free(buff);
 
     return (pttstat == 1) ? TRUE : FALSE;
@@ -3402,7 +3389,4 @@ void setconfig(gpointer data)
         g_async_queue_push(ctrl->rigctlq, ctrl);
     }
 }
-<<<<<<< HEAD
 
-=======
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d

--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -154,6 +154,8 @@ static void remove_timer (GtkRigCtrl *data );
 static void start_timer( GtkRigCtrl *data );
 
 gpointer rigctl_task_data = NULL;
+static GMutex       widgetsync;
+static GCond        widgetready;
 static GAsyncQueue *rigctlq;
 
 
@@ -235,9 +237,21 @@ static void gtk_rig_ctrl_destroy(GtkObject * object)
 {
     GtkRigCtrl     *ctrl = GTK_RIG_CTRL(object);
 
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: mutex lock..."),
+		__FILE__, __func__);
+
+    g_mutex_lock(&widgetsync);
+
     ctrl->engaged = 0;
     setconfig(ctrl);
-    
+
+    /* synchronization */
+    g_cond_wait(&widgetready, &widgetsync);
+    g_mutex_unlock(&widgetsync);
+
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: free config..."),
+		__FILE__, __func__);
+
     /* free configuration */
     if (ctrl->conf != NULL)
     {
@@ -720,7 +734,7 @@ static GtkWidget *create_conf_widgets(GtkRigCtrl * ctrl)
 
 
     sat_log_log(SAT_LOG_LEVEL_DEBUG,
-		_("%s:%s: context: %p"),
+		_("%s:%s: context: @%p"),
 		__FILE__, __func__, g_thread_self());
     
     table = gtk_table_new(4, 3, FALSE);
@@ -1402,18 +1416,12 @@ static gboolean rig_ctrl_timeout_cb(gpointer data)
 {
     GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
 
-    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: timeout! (id:%d)"),
-                __FILE__, __func__, ctrl->timerid);
-    sat_log_log(SAT_LOG_LEVEL_DEBUG,
-		_("%s:%s: context: %p"),
-		__FILE__, __func__, g_thread_self());
-
     if (ctrl->conf == NULL)
     {
         sat_log_log(SAT_LOG_LEVEL_ERROR,
                     _("%s:%s: Controller does not have a valid configuration"),
                     __FILE__, __func__);
-        return (TRUE);
+        return FALSE;
 
     }
 
@@ -2411,6 +2419,7 @@ static gboolean get_freq_simplex(GtkRigCtrl * ctrl, gint sock, gdouble * freq)
         retval = FALSE;
     }
 
+    g_free(buff);
     return retval;
 }
 
@@ -2454,6 +2463,7 @@ static gboolean get_freq_toggle(GtkRigCtrl * ctrl, gint sock, gdouble * freq)
         retval = FALSE;
     }
 
+    g_free(buff);
     return retval;
 }
 
@@ -3214,19 +3224,19 @@ gpointer rigctl_run( gpointer data )
 	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: started thread, wait for init..."),
 		    __FILE__, __func__);
 	sat_log_log(SAT_LOG_LEVEL_DEBUG,
-		    _("%s:%s: context: %p"),
+		    _("%s:%s: context: @%p"),
 		    __FILE__, __func__, g_thread_self());
       }
 
     while(1)
-      { 
+      {
 	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: ...idle..."),
 		    __FILE__, __func__);
 
 	ctrl = GTK_RIG_CTRL(g_async_queue_pop(rigctlq));
 	while (g_main_context_iteration(NULL, FALSE));
 
-	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: pop task..."),
+	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: pop event..."),
 		    __FILE__, __func__);
 
 	if(ctrl == NULL)
@@ -3236,7 +3246,7 @@ gpointer rigctl_run( gpointer data )
 	    continue;
 	  }
 	
-	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: ...[%p] busy..."),
+	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: ...[@%p] busy..."),
 		    __FILE__, __func__, g_thread_self());
 
 	if(ctrl->engaged)
@@ -3253,6 +3263,10 @@ gpointer rigctl_run( gpointer data )
 	  }
 	else
 	  {
+	    g_mutex_lock(&widgetsync);
+	    
+	    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: [@%p] tidy up..."),
+			__FILE__, __func__, g_thread_self());
 
 	    if(ctrl->sock > 0)
 	      {
@@ -3263,7 +3277,15 @@ gpointer rigctl_run( gpointer data )
 	      {
 		remove_timer(ctrl);
 	      }
+
+	    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: mutex unlock..."),
+			__FILE__, __func__);
+
+	    g_cond_signal(&widgetready);
+	    g_mutex_unlock(&widgetsync);
+	    continue;
 	  }
+
 	/*snip*/
 	check_aos_los(ctrl);
 
@@ -3323,7 +3345,6 @@ gpointer rigctl_run( gpointer data )
 
 	//g_print ("       WROPS = %d\n", ctrl->wrops);
 	/*snap*/
-    
       }
 
     /* NEVEREACHED: */
@@ -3341,7 +3362,7 @@ void start_timer( GtkRigCtrl *data )
     
     ctrl->timerid = gdk_threads_add_timeout(ctrl->delay, rig_ctrl_timeout_cb, ctrl);
     
-    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: [%p] added timer (id:%d) with delay %d"),
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: [@%p] added timer (id:%d) with delay %d"),
 		__FILE__, __func__, g_thread_self(), ctrl->timerid, ctrl->delay);
 }
 
@@ -3361,5 +3382,9 @@ void setconfig(gpointer data)
   GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
 
   if(ctrl != NULL)
+  {
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: push event..."),
+		__FILE__, __func__);
     g_async_queue_push(rigctlq, ctrl);
+  }
 }

--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -145,6 +145,17 @@ static inline gboolean check_get_response(gchar * buff, gboolean retcode,
 static gint     sat_name_compare(sat_t * a, sat_t * b);
 static gint     rig_name_compare(const gchar * a, const gchar * b);
 
+/* DL4PD: add thread for hamlib communication */
+static void rigctrl_open( GtkRigCtrl *data );
+static void rigctrl_close( GtkRigCtrl *data );
+//static void rigctrl_thread_func_close( GtkRigCtrl *data );
+static void setconfig(gpointer data);
+static void remove_timer (GtkRigCtrl *data );
+static void start_timer( GtkRigCtrl *data );
+
+gpointer rigctl_task_data = NULL;
+static GAsyncQueue *rigctlq;
+
 
 static GtkVBoxClass *parent_class = NULL;
 
@@ -224,10 +235,9 @@ static void gtk_rig_ctrl_destroy(GtkObject * object)
 {
     GtkRigCtrl     *ctrl = GTK_RIG_CTRL(object);
 
-    /* stop timer */
-    if (ctrl->timerid > 0)
-        g_source_remove(ctrl->timerid);
-
+    ctrl->engaged = 0;
+    setconfig(ctrl);
+    
     /* free configuration */
     if (ctrl->conf != NULL)
     {
@@ -251,11 +261,6 @@ static void gtk_rig_ctrl_destroy(GtkObject * object)
         ctrl->trsplist = NULL;
     }
 
-    /* close sockets if they are open */
-    if (ctrl->sock)
-        close_rigctld_socket(&(ctrl->sock));
-    if (ctrl->sock2)
-        close_rigctld_socket(&(ctrl->sock2));
     (*GTK_OBJECT_CLASS(parent_class)->destroy) (object);
 }
 
@@ -318,10 +323,6 @@ GtkWidget *gtk_rig_ctrl_new(GtkSatModule * module)
                      3, GTK_FILL | GTK_EXPAND, GTK_FILL | GTK_EXPAND, 0, 0);
 
     gtk_container_add(GTK_CONTAINER(widget), table);
-
-    GTK_RIG_CTRL(widget)->timerid = g_timeout_add(GTK_RIG_CTRL(widget)->delay,
-                                                  rig_ctrl_timeout_cb,
-                                                  GTK_RIG_CTRL(widget));
 
     if (module->target > 0)
         gtk_rig_ctrl_select_sat(GTK_RIG_CTRL(widget), module->target);
@@ -718,6 +719,10 @@ static GtkWidget *create_conf_widgets(GtkRigCtrl * ctrl)
     gchar          *rigname;
 
 
+    sat_log_log(SAT_LOG_LEVEL_DEBUG,
+		_("%s:%s: context: %p"),
+		__FILE__, __func__, g_thread_self());
+    
     table = gtk_table_new(4, 3, FALSE);
     gtk_container_set_border_width(GTK_CONTAINER(table), 5);
     gtk_table_set_col_spacings(GTK_TABLE(table), 5);
@@ -980,8 +985,8 @@ static void trsp_selected_cb(GtkComboBox * box, gpointer data)
     else
     {
         sat_log_log(SAT_LOG_LEVEL_ERROR,
-                    _("%s: Inconsistency detected in internal transponder "
-                      "data (%d,%d)"), __func__, i, n);
+                    _("%s:%s: Inconsistency detected in internal transponder "
+                      "data (%d,%d)"), __FILE__, __func__, i, n);
     }
 }
 
@@ -1081,10 +1086,10 @@ static void delay_changed_cb(GtkSpinButton * spin, gpointer data)
 
     ctrl->delay = (guint) gtk_spin_button_get_value(spin);
 
-    if (ctrl->timerid > 0)
-        g_source_remove(ctrl->timerid);
-
-    ctrl->timerid = g_timeout_add(ctrl->delay, rig_ctrl_timeout_cb, ctrl);
+    if (ctrl->engaged)
+      {
+	setconfig(ctrl);
+      }
 }
 
 /**
@@ -1274,8 +1279,8 @@ static void rig_engaged_cb(GtkToggleButton * button, gpointer data)
     {
         /* we don't have a working configuration */
         sat_log_log(SAT_LOG_LEVEL_ERROR,
-                    _("%s: Controller does not have a valid configuration"),
-                    __func__);
+                    _("%s:%s: Controller does not have a valid configuration"),
+                    __FILE__, __func__);
         return;
     }
 
@@ -1284,75 +1289,17 @@ static void rig_engaged_cb(GtkToggleButton * button, gpointer data)
         /* close socket */
         gtk_widget_set_sensitive(ctrl->DevSel, TRUE);
         gtk_widget_set_sensitive(ctrl->DevSel2, TRUE);
-        ctrl->engaged = FALSE;
-        ctrl->lasttxf = 0.0;
-        ctrl->lastrxf = 0.0;
-
-        if ((ctrl->conf->type == RIG_TYPE_TOGGLE_AUTO) ||
-            (ctrl->conf->type == RIG_TYPE_TOGGLE_MAN))
-        {
-            unset_toggle(ctrl, ctrl->sock);
-        }
-
-        if (ctrl->conf2 != NULL)
-        {
-            close_rigctld_socket(&(ctrl->sock2));
-        }
-        close_rigctld_socket(&(ctrl->sock));
+	ctrl->engaged = FALSE;
+	
+	setconfig(ctrl);
     }
     else
     {
         gtk_widget_set_sensitive(ctrl->DevSel, FALSE);
         gtk_widget_set_sensitive(ctrl->DevSel2, FALSE);
-        ctrl->engaged = TRUE;
-        ctrl->wrops = 0;
+	ctrl->engaged = TRUE;
 
-        open_rigctld_socket(ctrl->conf, &(ctrl->sock));
-
-        /* set initial frequency */
-        if (ctrl->conf2 != NULL)
-        {
-            open_rigctld_socket(ctrl->conf2, &(ctrl->sock2));
-            /* set initial dual mode */
-            exec_dual_rig_cycle(ctrl);
-        }
-        else
-        {
-            switch (ctrl->conf->type)
-            {
-
-            case RIG_TYPE_RX:
-                exec_rx_cycle(ctrl);
-                break;
-
-            case RIG_TYPE_TX:
-                exec_tx_cycle(ctrl);
-                break;
-
-            case RIG_TYPE_TRX:
-                exec_trx_cycle(ctrl);
-                break;
-
-            case RIG_TYPE_DUPLEX:
-                /* set rig into SAT mode (hamlib needs it even if rig already in SAT) */
-                setup_split(ctrl);
-                exec_duplex_cycle(ctrl);
-                break;
-
-            case RIG_TYPE_TOGGLE_AUTO:
-            case RIG_TYPE_TOGGLE_MAN:
-                set_toggle(ctrl, ctrl->sock);
-                ctrl->last_toggle_tx = -1;
-                exec_toggle_cycle(ctrl);
-                break;
-
-            default:
-                /* this is an error! */
-                ctrl->conf->type = RIG_TYPE_RX;
-                exec_rx_cycle(ctrl);
-                break;
-            }
-        }
+	setconfig(ctrl);
     }
 }
 
@@ -1455,11 +1402,17 @@ static gboolean rig_ctrl_timeout_cb(gpointer data)
 {
     GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
 
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: timeout! (id:%d)"),
+                __FILE__, __func__, ctrl->timerid);
+    sat_log_log(SAT_LOG_LEVEL_DEBUG,
+		_("%s:%s: context: %p"),
+		__FILE__, __func__, g_thread_self());
+
     if (ctrl->conf == NULL)
     {
         sat_log_log(SAT_LOG_LEVEL_ERROR,
-                    _("%s: Controller does not have a valid configuration"),
-                    __func__);
+                    _("%s:%s: Controller does not have a valid configuration"),
+                    __FILE__, __func__);
         return (TRUE);
 
     }
@@ -1471,63 +1424,8 @@ static gboolean rig_ctrl_timeout_cb(gpointer data)
         return TRUE;
     }
 
-    check_aos_los(ctrl);
-
-    if (ctrl->conf2 != NULL)
-    {
-        exec_dual_rig_cycle(ctrl);
-    }
-    else
-    {
-        /* Execute controller cycle depending on primary radio type */
-        switch (ctrl->conf->type)
-        {
-
-        case RIG_TYPE_RX:
-            exec_rx_cycle(ctrl);
-            break;
-
-        case RIG_TYPE_TX:
-            exec_tx_cycle(ctrl);
-            break;
-
-        case RIG_TYPE_TRX:
-            exec_trx_cycle(ctrl);
-            break;
-
-        case RIG_TYPE_DUPLEX:
-            exec_duplex_cycle(ctrl);
-            break;
-
-        case RIG_TYPE_TOGGLE_AUTO:
-        case RIG_TYPE_TOGGLE_MAN:
-            exec_toggle_cycle(ctrl);
-            break;
-
-        default:
-            /* invalid mode */
-            sat_log_log(SAT_LOG_LEVEL_ERROR,
-                        _("%s: Invalid radio type %d. Setting type to "
-                          "RIG_TYPE_RX"), __func__, ctrl->conf->type);
-            ctrl->conf->type = RIG_TYPE_RX;
-        }
-    }
-
-    /* perform error count checking */
-    if (ctrl->errcnt >= MAX_ERROR_COUNT)
-    {
-        /* disengage device */
-        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ctrl->LockBut), FALSE);
-        ctrl->engaged = FALSE;
-        ctrl->errcnt = 0;
-        sat_log_log(SAT_LOG_LEVEL_ERROR,
-                    _("%s: MAX_ERROR_COUNT (%d) reached. Disengaging device!"),
-                    __func__, MAX_ERROR_COUNT);
-
-        //g_print ("ERROR. WROPS = %d\n", ctrl->wrops);
-    }
-
-    //g_print ("       WROPS = %d\n", ctrl->wrops);
+    /* push event */
+    setconfig(ctrl);
 
     g_mutex_unlock(&(ctrl->busy));
 
@@ -2593,7 +2491,7 @@ static gboolean set_vfo(GtkRigCtrl * ctrl, vfo_t vfo)
 
     default:
         sat_log_log(SAT_LOG_LEVEL_ERROR,
-                    _("%s: Invalid VFO argument. Using VFOA."), __func__);
+                    _("%s:%s: Invalid VFO argument. Using VFOA."), __FILE__, __func__);
         buff = g_strdup_printf("V VFOA\x0a");
         break;
     }
@@ -2903,12 +2801,12 @@ gboolean send_rigctld_command(GtkRigCtrl * ctrl, gint sock, gchar * buff,
     if (written != size)
     {
         sat_log_log(SAT_LOG_LEVEL_ERROR,
-                    _("%s: SIZE ERROR %d / %d"), __func__, written, size);
+                    _("%s:%s: SIZE ERROR %d / %d"), __FILE__, __func__, written, size);
     }
     if (written == -1)
     {
         sat_log_log(SAT_LOG_LEVEL_ERROR,
-                    _("%s: rigctld port closed"), __func__);
+                    _("%s:%s: rigctld port closed"), __FILE__, __func__);
         return FALSE;
     }
     /* try to read answer */
@@ -2916,7 +2814,7 @@ gboolean send_rigctld_command(GtkRigCtrl * ctrl, gint sock, gchar * buff,
     if (size == -1)
     {
         sat_log_log(SAT_LOG_LEVEL_ERROR,
-                    _("%s: rigctld port closed"), __func__);
+                    _("%s:%s: rigctld port closed"), __FILE__, __func__);
         return FALSE;
     }
 
@@ -2964,7 +2862,7 @@ static gboolean key_press_cb(GtkWidget * widget, GdkEventKey * pKey,
             /* keyvals not in API docs. See <gdk/gdkkeysyms.h> for a complete list */
         case GDK_space:
             sat_log_log(SAT_LOG_LEVEL_INFO,
-                        _("%s: Detected SPACEBAR pressed event"), __func__);
+                        _("%s:%s: Detected SPACEBAR pressed event"), __FILE__, __func__);
 
             /* manage PTT event but only if rig is of type TOGGLE_MAN */
             if (ctrl->conf->type == RIG_TYPE_TOGGLE_MAN)
@@ -3028,13 +2926,13 @@ static void manage_ptt_event(GtkRigCtrl * ctrl)
     {
         /* timeout did not expire, we've got the controller lock */
         sat_log_log(SAT_LOG_LEVEL_DEBUG,
-                    _("%s: Acquired controller lock"), __func__);
+                    _("%s:%s: Acquired controller lock"), __FILE__, __func__);
 
         if (ctrl->engaged == FALSE)
         {
             sat_log_log(SAT_LOG_LEVEL_INFO,
-                        _("%s: Controller not engaged; PTT event ignored "
-                          "(Hint: Enable the Engage button)"), __func__);
+                        _("%s:%s: Controller not engaged; PTT event ignored "
+                          "(Hint: Enable the Engage button)"), __FILE__, __func__);
         }
         else
         {
@@ -3044,8 +2942,8 @@ static void manage_ptt_event(GtkRigCtrl * ctrl)
             {
                 /* PTT is OFF => set TX freq then set PTT to ON */
                 sat_log_log(SAT_LOG_LEVEL_DEBUG,
-                            _("%s: PTT is OFF => Set TX freq and PTT=ON"),
-                            __func__);
+                            _("%s:%s: PTT is OFF => Set TX freq and PTT=ON"),
+                            __FILE__, __func__);
 
                 exec_toggle_tx_cycle(ctrl);
                 set_ptt(ctrl, ctrl->sock, TRUE);
@@ -3054,7 +2952,7 @@ static void manage_ptt_event(GtkRigCtrl * ctrl)
             {
                 /* PTT is ON => set to OFF */
                 sat_log_log(SAT_LOG_LEVEL_DEBUG,
-                            _("%s: PTT is ON = Set PTT=OFF"), __func__);
+                            _("%s:%s: PTT is ON = Set PTT=OFF"), __FILE__, __func__);
 
                 set_ptt(ctrl, ctrl->sock, FALSE);
             }
@@ -3066,8 +2964,8 @@ static void manage_ptt_event(GtkRigCtrl * ctrl)
     else
     {
         sat_log_log(SAT_LOG_LEVEL_ERROR,
-                    _("%s: Failed to acquire controller lock; PTT event "
-                      "not handled"), __func__);
+                    _("%s:%s: Failed to acquire controller lock; PTT event "
+                      "not handled"), __FILE__, __func__);
     }
 
 }
@@ -3082,14 +2980,14 @@ static gboolean open_rigctld_socket(radio_conf_t * conf, gint * sock)
     if (*sock < 0)
     {
         sat_log_log(SAT_LOG_LEVEL_ERROR,
-                    _("%s: Failed to create socket"), __func__);
+                    _("%s:%s: Failed to create socket"), __FILE__, __func__);
         *sock = 0;
         return FALSE;
     }
     else
     {
         sat_log_log(SAT_LOG_LEVEL_DEBUG,
-                    _("%s: Network socket created successfully"), __func__);
+                    _("%s:%s: Network socket created successfully"), __FILE__, __func__);
     }
 
     memset(&ServAddr, 0, sizeof(ServAddr));     /* Zero out structure */
@@ -3103,16 +3001,16 @@ static gboolean open_rigctld_socket(radio_conf_t * conf, gint * sock)
     if (status < 0)
     {
         sat_log_log(SAT_LOG_LEVEL_ERROR,
-                    _("%s: Failed to connect to %s:%d"),
-                    __func__, conf->host, conf->port);
+                    _("%s:%s: Failed to connect to %s:%d"),
+                    __FILE__, __func__, conf->host, conf->port);
         *sock = 0;
         return FALSE;
     }
     else
     {
         sat_log_log(SAT_LOG_LEVEL_DEBUG,
-                    _("%s: Connection opened to %s:%d"),
-                    __func__, conf->host, conf->port);
+                    _("%s:%s: Connection opened to %s:%d"),
+                    __FILE__, __func__, conf->host, conf->port);
     }
 
     return TRUE;
@@ -3176,8 +3074,8 @@ static inline gboolean check_set_response(gchar * buffback, gboolean retcode,
         if (strncmp(buffback, "RPRT 0", 6) != 0)
         {
             sat_log_log(SAT_LOG_LEVEL_ERROR,
-                        _("%s: %s rigctld returned error (%s)"),
-                        __FILE__, function, buffback);
+                        _("%s:%s: %s rigctld returned error (%s)"),
+                        __FILE__, __func__, function, buffback);
 
             retcode = FALSE;
         }
@@ -3201,12 +3099,267 @@ static inline gboolean check_get_response(gchar * buffback, gboolean retcode,
         if (strncmp(buffback, "RPRT", 4) == 0)
         {
             sat_log_log(SAT_LOG_LEVEL_ERROR,
-                        _("%s: %s rigctld returned error (%s)"),
-                        __FILE__, function, buffback);
+                        _("%s:%s: %s rigctld returned error (%s)"),
+                        __FILE__, __func__, function, buffback);
 
             retcode = FALSE;
         }
     }
 
     return retcode;
+}
+
+static void rigctrl_close( GtkRigCtrl *data )
+{
+    GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
+    
+    ctrl->lasttxf = 0.0;
+    ctrl->lastrxf = 0.0;
+    
+    remove_timer(ctrl);
+    
+    if ((ctrl->conf->type == RIG_TYPE_TOGGLE_AUTO) ||
+	(ctrl->conf->type == RIG_TYPE_TOGGLE_MAN))
+    {
+	unset_toggle(ctrl, ctrl->sock);
+    }
+    
+    if (ctrl->conf2 != NULL)
+    {
+	close_rigctld_socket(&(ctrl->sock2));
+    }
+    close_rigctld_socket(&(ctrl->sock));
+}
+
+static void rigctrl_open( GtkRigCtrl *data )
+{
+    GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
+
+    ctrl->wrops = 0;
+
+    start_timer(ctrl);
+
+    open_rigctld_socket(ctrl->conf, &(ctrl->sock));
+
+    /* set initial frequency */
+    if (ctrl->conf2 != NULL)
+      {
+	open_rigctld_socket(ctrl->conf2, &(ctrl->sock2));
+	/* set initial dual mode */
+	exec_dual_rig_cycle(ctrl);
+      }
+    else
+      {
+	switch (ctrl->conf->type)
+	  {
+
+	  case RIG_TYPE_RX:
+	    exec_rx_cycle(ctrl);
+	    break;
+
+	  case RIG_TYPE_TX:
+	    exec_tx_cycle(ctrl);
+	    break;
+
+	  case RIG_TYPE_TRX:
+	    exec_trx_cycle(ctrl);
+	    break;
+
+	  case RIG_TYPE_DUPLEX:
+	    /* set rig into SAT mode (hamlib needs it even if rig already in SAT) */
+	    setup_split(ctrl);
+	    exec_duplex_cycle(ctrl);
+	    break;
+
+	  case RIG_TYPE_TOGGLE_AUTO:
+	  case RIG_TYPE_TOGGLE_MAN:
+	    set_toggle(ctrl, ctrl->sock);
+	    ctrl->last_toggle_tx = -1;
+	    exec_toggle_cycle(ctrl);
+	    break;
+
+	  default:
+	    /* this is an error! */
+	    ctrl->conf->type = RIG_TYPE_RX;
+	    exec_rx_cycle(ctrl);
+	    break;
+	  }
+      }
+}
+
+/**
+ * \brief Communication thread for hamlib rigctld
+ * \param data
+ * \return NULL
+ */
+gpointer rigctl_run( gpointer data )
+{
+    static GMutex   rigctl_in_progress;
+    GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
+
+    if (g_mutex_trylock(&rigctl_in_progress) == FALSE)
+    {
+        sat_log_log(SAT_LOG_LEVEL_ERROR,
+                    _("%s:%s: rigctl_run already running. Aborting."),
+                    __FILE__, __func__);
+
+        return NULL;
+    }
+
+    if(!ctrl)
+      {
+	rigctlq = g_async_queue_new();
+
+	/* thread is just started... */
+	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: started thread, wait for init..."),
+		    __FILE__, __func__);
+	sat_log_log(SAT_LOG_LEVEL_DEBUG,
+		    _("%s:%s: context: %p"),
+		    __FILE__, __func__, g_thread_self());
+      }
+
+    while(1)
+      { 
+	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: ...idle..."),
+		    __FILE__, __func__);
+
+	ctrl = GTK_RIG_CTRL(g_async_queue_pop(rigctlq));
+	while (g_main_context_iteration(NULL, FALSE));
+
+	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: pop task..."),
+		    __FILE__, __func__);
+
+	if(ctrl == NULL)
+	  {
+	    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: ERROR: NO VALID ctrl-struct"),
+			__FILE__, __func__);
+	    continue;
+	  }
+	
+	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: ...[%p] busy..."),
+		    __FILE__, __func__, g_thread_self());
+
+	if(ctrl->engaged)
+	  {
+	    if(!ctrl->sock)
+	      {
+		rigctrl_open(ctrl);
+	      }
+	
+	    if(!ctrl->timerid)
+	      {
+		start_timer(ctrl);
+	      }
+	  }
+	else
+	  {
+
+	    if(ctrl->sock > 0)
+	      {
+		rigctrl_close(ctrl);
+	      }
+	
+	    if(ctrl->timerid)
+	      {
+		remove_timer(ctrl);
+	      }
+	  }
+	/*snip*/
+	check_aos_los(ctrl);
+
+	if (ctrl->conf2 != NULL)
+	  {
+	    exec_dual_rig_cycle(ctrl);
+	  }
+	else
+	  {
+	    /* Execute controller cycle depending on primary radio type */
+	    switch (ctrl->conf->type)
+	      {
+
+	      case RIG_TYPE_RX:
+		exec_rx_cycle(ctrl);
+		break;
+
+	      case RIG_TYPE_TX:
+		exec_tx_cycle(ctrl);
+		break;
+
+	      case RIG_TYPE_TRX:
+		exec_trx_cycle(ctrl);
+		break;
+
+	      case RIG_TYPE_DUPLEX:
+		exec_duplex_cycle(ctrl);
+		break;
+
+	      case RIG_TYPE_TOGGLE_AUTO:
+	      case RIG_TYPE_TOGGLE_MAN:
+		exec_toggle_cycle(ctrl);
+		break;
+
+	      default:
+		/* invalid mode */
+		sat_log_log(SAT_LOG_LEVEL_ERROR,
+			    _("%s:%s: Invalid radio type %d. Setting type to "
+			      "RIG_TYPE_RX"), __FILE__, __func__, ctrl->conf->type);
+		ctrl->conf->type = RIG_TYPE_RX;
+	      }
+	  }
+
+	/* perform error count checking */
+	if (ctrl->errcnt >= MAX_ERROR_COUNT)
+	  {
+	    /* disengage device */
+	    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ctrl->LockBut), FALSE);
+	    ctrl->engaged = FALSE;
+	    ctrl->errcnt = 0;
+	    sat_log_log(SAT_LOG_LEVEL_ERROR,
+			_("%s:%s: MAX_ERROR_COUNT (%d) reached. Disengaging device!"),
+			__FILE__, __func__, MAX_ERROR_COUNT);
+
+	    //g_print ("ERROR. WROPS = %d\n", ctrl->wrops);
+	  }
+
+	//g_print ("       WROPS = %d\n", ctrl->wrops);
+	/*snap*/
+    
+      }
+
+    /* NEVEREACHED: */
+    g_mutex_unlock(&rigctl_in_progress);
+    return NULL;
+}
+
+void start_timer( GtkRigCtrl *data )
+{
+    GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
+    
+    /* DL4PD: start timeout timer here ("Cycle")! */
+    if (ctrl->timerid > 0)
+      g_source_remove(ctrl->timerid);
+    
+    ctrl->timerid = gdk_threads_add_timeout(ctrl->delay, rig_ctrl_timeout_cb, ctrl);
+    
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: [%p] added timer (id:%d) with delay %d"),
+		__FILE__, __func__, g_thread_self(), ctrl->timerid, ctrl->delay);
+}
+
+void remove_timer (GtkRigCtrl *data )
+{
+    GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
+
+    /* stop timer */
+    if (ctrl->timerid > 0)
+        g_source_remove(ctrl->timerid);
+    ctrl->timerid = 0;
+}
+
+void setconfig(gpointer data)
+{
+  /* something has changed... */
+  GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
+
+  if(ctrl != NULL)
+    g_async_queue_push(rigctlq, ctrl);
 }

--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -3296,7 +3296,7 @@ gpointer rigctl_run(gpointer data)
                     _("%s:%s: rigctl_run already running. Aborting."),
                     __FILE__, __func__);
 
-        return NULL;
+        goto exit_thread;
     }
 
     while (1)
@@ -3422,6 +3422,7 @@ gpointer rigctl_run(gpointer data)
         /*snap */
     }
 
+exit_thread:
     g_mutex_unlock(&rigctl_in_progress);
     return NULL;
 }

--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -1113,7 +1113,7 @@ static void delay_changed_cb(GtkSpinButton * spin, gpointer data)
 
     if (ctrl->engaged)
     {
-        setconfig(ctrl);
+	start_timer(ctrl);
     }
 }
 

--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -146,16 +146,17 @@ static gint     sat_name_compare(sat_t * a, sat_t * b);
 static gint     rig_name_compare(const gchar * a, const gchar * b);
 
 /* DL4PD: add thread for hamlib communication */
-static void rigctrl_open( GtkRigCtrl *data );
-static void rigctrl_close( GtkRigCtrl *data );
-//static void rigctrl_thread_func_close( GtkRigCtrl *data );
-static void setconfig(gpointer data);
-static void remove_timer (GtkRigCtrl *data );
-static void start_timer( GtkRigCtrl *data );
+static void     rigctrl_open(GtkRigCtrl * data);
+static void     rigctrl_close(GtkRigCtrl * data);
 
-gpointer rigctl_task_data = NULL;
-static GMutex       widgetsync;
-static GCond        widgetready;
+//static void rigctrl_thread_func_close( GtkRigCtrl *data );
+static void     setconfig(gpointer data);
+static void     remove_timer(GtkRigCtrl * data);
+static void     start_timer(GtkRigCtrl * data);
+static GThread *rigctl_thread = NULL;
+
+static GMutex   widgetsync;
+static GCond    widgetready;
 static GAsyncQueue *rigctlq;
 
 
@@ -237,20 +238,25 @@ static void gtk_rig_ctrl_destroy(GtkObject * object)
 {
     GtkRigCtrl     *ctrl = GTK_RIG_CTRL(object);
 
-    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: mutex lock..."),
-		__FILE__, __func__);
+    if (rigctl_thread != NULL)
+    {
 
-    g_mutex_lock(&widgetsync);
+        sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: mutex lock..."),
+                    __FILE__, __func__);
 
-    ctrl->engaged = 0;
-    setconfig(ctrl);
+        g_mutex_lock(&widgetsync);
 
-    /* synchronization */
-    g_cond_wait(&widgetready, &widgetsync);
-    g_mutex_unlock(&widgetsync);
+        ctrl->engaged = 0;
+        setconfig(ctrl);
+
+        /* synchronization */
+        g_cond_wait(&widgetready, &widgetsync);
+        g_mutex_unlock(&widgetsync);
+        rigctl_thread = NULL;
+    }
 
     sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: free config..."),
-		__FILE__, __func__);
+                __FILE__, __func__);
 
     /* free configuration */
     if (ctrl->conf != NULL)
@@ -283,7 +289,7 @@ static void gtk_rig_ctrl_destroy(GtkObject * object)
  * \return A new rig control window.
  * 
  */
-GtkWidget *gtk_rig_ctrl_new(GtkSatModule * module)
+GtkWidget      *gtk_rig_ctrl_new(GtkSatModule * module)
 {
     GtkWidget      *widget;
     GtkWidget      *table;
@@ -430,8 +436,8 @@ void gtk_rig_ctrl_update(GtkRigCtrl * ctrl, gdouble t)
 /** Select a satellite */
 void gtk_rig_ctrl_select_sat(GtkRigCtrl * ctrl, gint catnum)
 {
-    sat_t      *sat;
-    int         i, n;
+    sat_t          *sat;
+    int             i, n;
 
     /* find index in satellite list */
     n = g_slist_length(ctrl->sats);
@@ -611,12 +617,14 @@ static GtkWidget *create_target_widgets(GtkRigCtrl * ctrl)
     {
         sat = SAT(g_slist_nth_data(ctrl->sats, i));
         if (sat)
-            gtk_combo_box_append_text(GTK_COMBO_BOX(ctrl->SatSel), sat->nickname);
+            gtk_combo_box_append_text(GTK_COMBO_BOX(ctrl->SatSel),
+                                      sat->nickname);
     }
 
     gtk_combo_box_set_active(GTK_COMBO_BOX(ctrl->SatSel), 0);
     gtk_widget_set_tooltip_text(ctrl->SatSel, _("Select target object"));
-    g_signal_connect(ctrl->SatSel, "changed", G_CALLBACK(sat_selected_cb), ctrl);
+    g_signal_connect(ctrl->SatSel, "changed", G_CALLBACK(sat_selected_cb),
+                     ctrl);
     gtk_table_attach_defaults(GTK_TABLE(table), ctrl->SatSel, 0, 3, 0, 1);
 
     /* tracking button */
@@ -734,9 +742,8 @@ static GtkWidget *create_conf_widgets(GtkRigCtrl * ctrl)
 
 
     sat_log_log(SAT_LOG_LEVEL_DEBUG,
-		_("%s:%s: context: @%p"),
-		__FILE__, __func__, g_thread_self());
-    
+                _("%s:%s: context: @%p"), __FILE__, __func__, g_thread_self());
+
     table = gtk_table_new(4, 3, FALSE);
     gtk_container_set_border_width(GTK_CONTAINER(table), 5);
     gtk_table_set_col_spacings(GTK_TABLE(table), 5);
@@ -1101,9 +1108,9 @@ static void delay_changed_cb(GtkSpinButton * spin, gpointer data)
     ctrl->delay = (guint) gtk_spin_button_get_value(spin);
 
     if (ctrl->engaged)
-      {
-	setconfig(ctrl);
-      }
+    {
+        setconfig(ctrl);
+    }
 }
 
 /**
@@ -1303,17 +1310,22 @@ static void rig_engaged_cb(GtkToggleButton * button, gpointer data)
         /* close socket */
         gtk_widget_set_sensitive(ctrl->DevSel, TRUE);
         gtk_widget_set_sensitive(ctrl->DevSel2, TRUE);
-	ctrl->engaged = FALSE;
-	
-	setconfig(ctrl);
+        ctrl->engaged = FALSE;
+
+        /* DL4PD: stop worker thread... */
+        setconfig(ctrl);
+        rigctl_thread = NULL;
     }
     else
     {
         gtk_widget_set_sensitive(ctrl->DevSel, FALSE);
         gtk_widget_set_sensitive(ctrl->DevSel2, FALSE);
-	ctrl->engaged = TRUE;
+        ctrl->engaged = TRUE;
 
-	setconfig(ctrl);
+        /* DL4PD: start worker thread... */
+        rigctlq = g_async_queue_new();
+        rigctl_thread = g_thread_new("rigtcl_run", rigctl_run, ctrl);
+        setconfig(ctrl);
     }
 }
 
@@ -2501,7 +2513,8 @@ static gboolean set_vfo(GtkRigCtrl * ctrl, vfo_t vfo)
 
     default:
         sat_log_log(SAT_LOG_LEVEL_ERROR,
-                    _("%s:%s: Invalid VFO argument. Using VFOA."), __FILE__, __func__);
+                    _("%s:%s: Invalid VFO argument. Using VFOA."), __FILE__,
+                    __func__);
         buff = g_strdup_printf("V VFOA\x0a");
         break;
     }
@@ -2811,7 +2824,8 @@ gboolean send_rigctld_command(GtkRigCtrl * ctrl, gint sock, gchar * buff,
     if (written != size)
     {
         sat_log_log(SAT_LOG_LEVEL_ERROR,
-                    _("%s:%s: SIZE ERROR %d / %d"), __FILE__, __func__, written, size);
+                    _("%s:%s: SIZE ERROR %d / %d"), __FILE__, __func__,
+                    written, size);
     }
     if (written == -1)
     {
@@ -2872,7 +2886,8 @@ static gboolean key_press_cb(GtkWidget * widget, GdkEventKey * pKey,
             /* keyvals not in API docs. See <gdk/gdkkeysyms.h> for a complete list */
         case GDK_space:
             sat_log_log(SAT_LOG_LEVEL_INFO,
-                        _("%s:%s: Detected SPACEBAR pressed event"), __FILE__, __func__);
+                        _("%s:%s: Detected SPACEBAR pressed event"), __FILE__,
+                        __func__);
 
             /* manage PTT event but only if rig is of type TOGGLE_MAN */
             if (ctrl->conf->type == RIG_TYPE_TOGGLE_MAN)
@@ -2942,7 +2957,8 @@ static void manage_ptt_event(GtkRigCtrl * ctrl)
         {
             sat_log_log(SAT_LOG_LEVEL_INFO,
                         _("%s:%s: Controller not engaged; PTT event ignored "
-                          "(Hint: Enable the Engage button)"), __FILE__, __func__);
+                          "(Hint: Enable the Engage button)"), __FILE__,
+                        __func__);
         }
         else
         {
@@ -2962,7 +2978,8 @@ static void manage_ptt_event(GtkRigCtrl * ctrl)
             {
                 /* PTT is ON => set to OFF */
                 sat_log_log(SAT_LOG_LEVEL_DEBUG,
-                            _("%s:%s: PTT is ON = Set PTT=OFF"), __FILE__, __func__);
+                            _("%s:%s: PTT is ON = Set PTT=OFF"), __FILE__,
+                            __func__);
 
                 set_ptt(ctrl, ctrl->sock, FALSE);
             }
@@ -2997,7 +3014,8 @@ static gboolean open_rigctld_socket(radio_conf_t * conf, gint * sock)
     else
     {
         sat_log_log(SAT_LOG_LEVEL_DEBUG,
-                    _("%s:%s: Network socket created successfully"), __FILE__, __func__);
+                    _("%s:%s: Network socket created successfully"), __FILE__,
+                    __func__);
     }
 
     memset(&ServAddr, 0, sizeof(ServAddr));     /* Zero out structure */
@@ -3119,29 +3137,29 @@ static inline gboolean check_get_response(gchar * buffback, gboolean retcode,
     return retcode;
 }
 
-static void rigctrl_close( GtkRigCtrl *data )
+static void rigctrl_close(GtkRigCtrl * data)
 {
     GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
-    
+
     ctrl->lasttxf = 0.0;
     ctrl->lastrxf = 0.0;
-    
+
     remove_timer(ctrl);
-    
+
     if ((ctrl->conf->type == RIG_TYPE_TOGGLE_AUTO) ||
-	(ctrl->conf->type == RIG_TYPE_TOGGLE_MAN))
+        (ctrl->conf->type == RIG_TYPE_TOGGLE_MAN))
     {
-	unset_toggle(ctrl, ctrl->sock);
+        unset_toggle(ctrl, ctrl->sock);
     }
-    
+
     if (ctrl->conf2 != NULL)
     {
-	close_rigctld_socket(&(ctrl->sock2));
+        close_rigctld_socket(&(ctrl->sock2));
     }
     close_rigctld_socket(&(ctrl->sock));
 }
 
-static void rigctrl_open( GtkRigCtrl *data )
+static void rigctrl_open(GtkRigCtrl * data)
 {
     GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
 
@@ -3153,48 +3171,48 @@ static void rigctrl_open( GtkRigCtrl *data )
 
     /* set initial frequency */
     if (ctrl->conf2 != NULL)
-      {
-	open_rigctld_socket(ctrl->conf2, &(ctrl->sock2));
-	/* set initial dual mode */
-	exec_dual_rig_cycle(ctrl);
-      }
+    {
+        open_rigctld_socket(ctrl->conf2, &(ctrl->sock2));
+        /* set initial dual mode */
+        exec_dual_rig_cycle(ctrl);
+    }
     else
-      {
-	switch (ctrl->conf->type)
-	  {
+    {
+        switch (ctrl->conf->type)
+        {
 
-	  case RIG_TYPE_RX:
-	    exec_rx_cycle(ctrl);
-	    break;
+        case RIG_TYPE_RX:
+            exec_rx_cycle(ctrl);
+            break;
 
-	  case RIG_TYPE_TX:
-	    exec_tx_cycle(ctrl);
-	    break;
+        case RIG_TYPE_TX:
+            exec_tx_cycle(ctrl);
+            break;
 
-	  case RIG_TYPE_TRX:
-	    exec_trx_cycle(ctrl);
-	    break;
+        case RIG_TYPE_TRX:
+            exec_trx_cycle(ctrl);
+            break;
 
-	  case RIG_TYPE_DUPLEX:
-	    /* set rig into SAT mode (hamlib needs it even if rig already in SAT) */
-	    setup_split(ctrl);
-	    exec_duplex_cycle(ctrl);
-	    break;
+        case RIG_TYPE_DUPLEX:
+            /* set rig into SAT mode (hamlib needs it even if rig already in SAT) */
+            setup_split(ctrl);
+            exec_duplex_cycle(ctrl);
+            break;
 
-	  case RIG_TYPE_TOGGLE_AUTO:
-	  case RIG_TYPE_TOGGLE_MAN:
-	    set_toggle(ctrl, ctrl->sock);
-	    ctrl->last_toggle_tx = -1;
-	    exec_toggle_cycle(ctrl);
-	    break;
+        case RIG_TYPE_TOGGLE_AUTO:
+        case RIG_TYPE_TOGGLE_MAN:
+            set_toggle(ctrl, ctrl->sock);
+            ctrl->last_toggle_tx = -1;
+            exec_toggle_cycle(ctrl);
+            break;
 
-	  default:
-	    /* this is an error! */
-	    ctrl->conf->type = RIG_TYPE_RX;
-	    exec_rx_cycle(ctrl);
-	    break;
-	  }
-      }
+        default:
+            /* this is an error! */
+            ctrl->conf->type = RIG_TYPE_RX;
+            exec_rx_cycle(ctrl);
+            break;
+        }
+    }
 }
 
 /**
@@ -3202,7 +3220,7 @@ static void rigctrl_open( GtkRigCtrl *data )
  * \param data
  * \return NULL
  */
-gpointer rigctl_run( gpointer data )
+gpointer rigctl_run(gpointer data)
 {
     static GMutex   rigctl_in_progress;
     GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
@@ -3216,157 +3234,164 @@ gpointer rigctl_run( gpointer data )
         return NULL;
     }
 
-    if(!ctrl)
-      {
-	rigctlq = g_async_queue_new();
+#if 0
+    if (!ctrl)
+    {
+        rigctlq = g_async_queue_new();
 
-	/* thread is just started... */
-	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: started thread, wait for init..."),
-		    __FILE__, __func__);
-	sat_log_log(SAT_LOG_LEVEL_DEBUG,
-		    _("%s:%s: context: @%p"),
-		    __FILE__, __func__, g_thread_self());
-      }
+        /* thread is just started... */
+        sat_log_log(SAT_LOG_LEVEL_DEBUG,
+                    _("%s:%s: started thread, wait for init..."), __FILE__,
+                    __func__);
+        sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: context: @%p"), __FILE__,
+                    __func__, g_thread_self());
+    }
+#endif
 
-    while(1)
-      {
-	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: ...idle..."),
-		    __FILE__, __func__);
+    while (1)
+    {
+        sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: ...idle..."),
+                    __FILE__, __func__);
 
-	ctrl = GTK_RIG_CTRL(g_async_queue_pop(rigctlq));
-	while (g_main_context_iteration(NULL, FALSE));
+        ctrl = GTK_RIG_CTRL(g_async_queue_pop(rigctlq));
+        while (g_main_context_iteration(NULL, FALSE));
 
-	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: pop event..."),
-		    __FILE__, __func__);
+        sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: pop event..."),
+                    __FILE__, __func__);
 
-	if(ctrl == NULL)
-	  {
-	    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: ERROR: NO VALID ctrl-struct"),
-			__FILE__, __func__);
-	    continue;
-	  }
-	
-	sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: ...[@%p] busy..."),
-		    __FILE__, __func__, g_thread_self());
+        if (ctrl == NULL)
+        {
+            sat_log_log(SAT_LOG_LEVEL_DEBUG,
+                        _("%s:%s: ERROR: NO VALID ctrl-struct"), __FILE__,
+                        __func__);
+            continue;
+        }
 
-	if(ctrl->engaged)
-	  {
-	    if(!ctrl->sock)
-	      {
-		rigctrl_open(ctrl);
-	      }
-	
-	    if(!ctrl->timerid)
-	      {
-		start_timer(ctrl);
-	      }
-	  }
-	else
-	  {
-	    g_mutex_lock(&widgetsync);
-	    
-	    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: [@%p] tidy up..."),
-			__FILE__, __func__, g_thread_self());
+        sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: ...[@%p] busy..."),
+                    __FILE__, __func__, g_thread_self());
 
-	    if(ctrl->sock > 0)
-	      {
-		rigctrl_close(ctrl);
-	      }
-	
-	    if(ctrl->timerid)
-	      {
-		remove_timer(ctrl);
-	      }
+        if (ctrl->engaged)
+        {
+            if (!ctrl->sock)
+            {
+                rigctrl_open(ctrl);
+            }
 
-	    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: mutex unlock..."),
-			__FILE__, __func__);
+            if (!ctrl->timerid)
+            {
+                start_timer(ctrl);
+            }
+        }
+        else
+        {
+            g_mutex_lock(&widgetsync);
 
-	    g_cond_signal(&widgetready);
-	    g_mutex_unlock(&widgetsync);
-	    continue;
-	  }
+            sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: [@%p] tidy up..."),
+                        __FILE__, __func__, g_thread_self());
 
-	/*snip*/
-	check_aos_los(ctrl);
+            if (ctrl->sock > 0)
+            {
+                rigctrl_close(ctrl);
+            }
 
-	if (ctrl->conf2 != NULL)
-	  {
-	    exec_dual_rig_cycle(ctrl);
-	  }
-	else
-	  {
-	    /* Execute controller cycle depending on primary radio type */
-	    switch (ctrl->conf->type)
-	      {
+            if (ctrl->timerid)
+            {
+                remove_timer(ctrl);
+            }
 
-	      case RIG_TYPE_RX:
-		exec_rx_cycle(ctrl);
-		break;
+            sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: mutex unlock..."),
+                        __FILE__, __func__);
 
-	      case RIG_TYPE_TX:
-		exec_tx_cycle(ctrl);
-		break;
+            g_cond_signal(&widgetready);
+            g_mutex_unlock(&widgetsync);
+            break;
+        }
 
-	      case RIG_TYPE_TRX:
-		exec_trx_cycle(ctrl);
-		break;
+        /*snip */
+        check_aos_los(ctrl);
 
-	      case RIG_TYPE_DUPLEX:
-		exec_duplex_cycle(ctrl);
-		break;
+        if (ctrl->conf2 != NULL)
+        {
+            exec_dual_rig_cycle(ctrl);
+        }
+        else
+        {
+            /* Execute controller cycle depending on primary radio type */
+            switch (ctrl->conf->type)
+            {
 
-	      case RIG_TYPE_TOGGLE_AUTO:
-	      case RIG_TYPE_TOGGLE_MAN:
-		exec_toggle_cycle(ctrl);
-		break;
+            case RIG_TYPE_RX:
+                exec_rx_cycle(ctrl);
+                break;
 
-	      default:
-		/* invalid mode */
-		sat_log_log(SAT_LOG_LEVEL_ERROR,
-			    _("%s:%s: Invalid radio type %d. Setting type to "
-			      "RIG_TYPE_RX"), __FILE__, __func__, ctrl->conf->type);
-		ctrl->conf->type = RIG_TYPE_RX;
-	      }
-	  }
+            case RIG_TYPE_TX:
+                exec_tx_cycle(ctrl);
+                break;
 
-	/* perform error count checking */
-	if (ctrl->errcnt >= MAX_ERROR_COUNT)
-	  {
-	    /* disengage device */
-	    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ctrl->LockBut), FALSE);
-	    ctrl->engaged = FALSE;
-	    ctrl->errcnt = 0;
-	    sat_log_log(SAT_LOG_LEVEL_ERROR,
-			_("%s:%s: MAX_ERROR_COUNT (%d) reached. Disengaging device!"),
-			__FILE__, __func__, MAX_ERROR_COUNT);
+            case RIG_TYPE_TRX:
+                exec_trx_cycle(ctrl);
+                break;
 
-	    //g_print ("ERROR. WROPS = %d\n", ctrl->wrops);
-	  }
+            case RIG_TYPE_DUPLEX:
+                exec_duplex_cycle(ctrl);
+                break;
 
-	//g_print ("       WROPS = %d\n", ctrl->wrops);
-	/*snap*/
-      }
+            case RIG_TYPE_TOGGLE_AUTO:
+            case RIG_TYPE_TOGGLE_MAN:
+                exec_toggle_cycle(ctrl);
+                break;
 
-    /* NEVEREACHED: */
+            default:
+                /* invalid mode */
+                sat_log_log(SAT_LOG_LEVEL_ERROR,
+                            _("%s:%s: Invalid radio type %d. Setting type to "
+                              "RIG_TYPE_RX"), __FILE__, __func__,
+                            ctrl->conf->type);
+                ctrl->conf->type = RIG_TYPE_RX;
+            }
+        }
+
+        /* perform error count checking */
+        if (ctrl->errcnt >= MAX_ERROR_COUNT)
+        {
+            /* disengage device */
+            gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ctrl->LockBut),
+                                         FALSE);
+            ctrl->engaged = FALSE;
+            ctrl->errcnt = 0;
+            sat_log_log(SAT_LOG_LEVEL_ERROR,
+                        _
+                        ("%s:%s: MAX_ERROR_COUNT (%d) reached. Disengaging device!"),
+                        __FILE__, __func__, MAX_ERROR_COUNT);
+
+            //g_print ("ERROR. WROPS = %d\n", ctrl->wrops);
+        }
+
+        //g_print ("       WROPS = %d\n", ctrl->wrops);
+        /*snap */
+    }
+
     g_mutex_unlock(&rigctl_in_progress);
     return NULL;
 }
 
-void start_timer( GtkRigCtrl *data )
+void start_timer(GtkRigCtrl * data)
 {
     GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
-    
+
     /* DL4PD: start timeout timer here ("Cycle")! */
     if (ctrl->timerid > 0)
-      g_source_remove(ctrl->timerid);
-    
-    ctrl->timerid = gdk_threads_add_timeout(ctrl->delay, rig_ctrl_timeout_cb, ctrl);
-    
-    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: [@%p] added timer (id:%d) with delay %d"),
-		__FILE__, __func__, g_thread_self(), ctrl->timerid, ctrl->delay);
+        g_source_remove(ctrl->timerid);
+
+    ctrl->timerid =
+        gdk_threads_add_timeout(ctrl->delay, rig_ctrl_timeout_cb, ctrl);
+
+    sat_log_log(SAT_LOG_LEVEL_DEBUG,
+                _("%s:%s: [@%p] added timer (id:%d) with delay %d"), __FILE__,
+                __func__, g_thread_self(), ctrl->timerid, ctrl->delay);
 }
 
-void remove_timer (GtkRigCtrl *data )
+void remove_timer(GtkRigCtrl * data)
 {
     GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
 
@@ -3378,13 +3403,13 @@ void remove_timer (GtkRigCtrl *data )
 
 void setconfig(gpointer data)
 {
-  /* something has changed... */
-  GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
+    /* something has changed... */
+    GtkRigCtrl     *ctrl = GTK_RIG_CTRL(data);
 
-  if(ctrl != NULL)
-  {
-    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: push event..."),
-		__FILE__, __func__);
-    g_async_queue_push(rigctlq, ctrl);
-  }
+    if (ctrl != NULL)
+    {
+        sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: push event..."),
+                    __FILE__, __func__);
+        g_async_queue_push(rigctlq, ctrl);
+    }
 }

--- a/src/gtk-rig-ctrl.h
+++ b/src/gtk-rig-ctrl.h
@@ -112,19 +112,11 @@ struct _gtk_rig_ctrl {
     /* DL4PD */
     /* threads related stuff */
     /* add mutexes etc, to make threads reentrant! */
-<<<<<<< HEAD
     GMutex          writelock;          /*!< Mutex for blocking write operation */
     GMutex          rig_ctrl_updatelock;/*!< Mutex wile updating widgets etc */
     GMutex          widgetsync;         /*!< Mutex used while leaving (sync stuff) */
     GCond           widgetready;        /*!< Condition when work is done (sync stuff) */
     GAsyncQueue    *rigctlq;            /*!< Message queue to indicate something has changed */
-=======
-    GMutex          writelock;  /*!< Mutex for blocking write operation */
-    GMutex          rig_ctrl_updatelock;        /*!< Mutex wile updating widgets etc */
-    GMutex          widgetsync; /*!< Mutex used while leaving (sync stuff) */
-    GCond           widgetready;        /*!< Condition when work is done (sync stuff) */
-    GAsyncQueue    *rigctlq;    /*!< Message queue to indicate something has changed */
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
     GThread        *rigctl_thread;      /*!< Pointer to current rigctl-thread */
 };
 

--- a/src/gtk-rig-ctrl.h
+++ b/src/gtk-rig-ctrl.h
@@ -108,6 +108,16 @@ struct _gtk_rig_ctrl {
     /* debug related */
     guint           wrops;
     guint           rdops;
+
+    /* DL4PD */
+    /* threads related stuff */
+    /* add mutexes etc, to make threads reentrant! */
+    GMutex          writelock;          /*!< Mutex for blocking write operation */
+    GMutex          rig_ctrl_updatelock;/*!< Mutex wile updating widgets etc */
+    GMutex          widgetsync;         /*!< Mutex used while leaving (sync stuff) */
+    GCond           widgetready;        /*!< Condition when work is done (sync stuff) */
+    GAsyncQueue    *rigctlq;            /*!< Message queue to indicate something has changed */
+    GThread        *rigctl_thread;      /*!< Pointer to current rigctl-thread */
 };
 
 struct _GtkRigCtrlClass {

--- a/src/gtk-rig-ctrl.h
+++ b/src/gtk-rig-ctrl.h
@@ -118,9 +118,5 @@ GType           gtk_rig_ctrl_get_type(void);
 GtkWidget      *gtk_rig_ctrl_new(GtkSatModule * module);
 void            gtk_rig_ctrl_update(GtkRigCtrl * ctrl, gdouble t);
 void            gtk_rig_ctrl_select_sat(GtkRigCtrl * ctrl, gint catnum);
-gpointer rigctl_run( gpointer data );
-
-extern gpointer rigctl_task_data;
-
 
 #endif /* __GTK_RIG_CTRL_H__ */

--- a/src/gtk-rig-ctrl.h
+++ b/src/gtk-rig-ctrl.h
@@ -118,5 +118,9 @@ GType           gtk_rig_ctrl_get_type(void);
 GtkWidget      *gtk_rig_ctrl_new(GtkSatModule * module);
 void            gtk_rig_ctrl_update(GtkRigCtrl * ctrl, gdouble t);
 void            gtk_rig_ctrl_select_sat(GtkRigCtrl * ctrl, gint catnum);
+gpointer rigctl_run( gpointer data );
+
+extern gpointer rigctl_task_data;
+
 
 #endif /* __GTK_RIG_CTRL_H__ */

--- a/src/gtk-rot-ctrl.c
+++ b/src/gtk-rot-ctrl.c
@@ -1496,7 +1496,7 @@ gpointer rotctl_run(gpointer data)
                     _("%s:%s: rotctl_run already running. Aborting."),
                     __FILE__, __func__);
 
-        return NULL;
+        goto exit_thread;
     }
 
 
@@ -1818,6 +1818,7 @@ gpointer rotctl_run(gpointer data)
 	}
     }
 
+exit_thread:
     g_mutex_unlock(&rotctl_in_progress);
     return NULL;
 }

--- a/src/gtk-rot-ctrl.c
+++ b/src/gtk-rot-ctrl.c
@@ -814,7 +814,7 @@ static void delay_changed_cb(GtkSpinButton * spin, gpointer data)
 
     if (ctrl->engaged)
     {
-        setconfig(ctrl);
+	start_timer(ctrl);
     }
 
 #if 0

--- a/src/gtk-rot-ctrl.c
+++ b/src/gtk-rot-ctrl.c
@@ -109,36 +109,13 @@ static GtkVBoxClass *parent_class = NULL;
 
 
 /* DL4PD: add thread for hamlib communication */
-<<<<<<< HEAD
 gpointer        rotctl_run(gpointer data);
-=======
-gpointer        rotctl_run( gpointer data );
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
 static void     rotctrl_open(GtkRotCtrl * data);
 static void     rotctrl_close(GtkRotCtrl * data);
 static void     setconfig(gpointer data);
 static void     remove_timer(GtkRotCtrl * data);
 static void     start_timer(GtkRotCtrl * data);
 void           *update_display_widgets(gpointer data);
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
-static GThread *rotctl_thread = NULL;
-
-static GMutex   widgetsync;
-static GCond    widgetready;
-static GAsyncQueue *rotctlq;
-gdouble         rotaz = 0.0, rotel = 0.0;
-gdouble         setaz = 0.0, setel = 45.0;
-
-G_LOCK_DEFINE_STATIC(writelock);
-G_LOCK_DEFINE_STATIC(rot_ctrl_updatelock);
-G_LOCK_DEFINE_STATIC(setpos);
-G_LOCK_DEFINE_STATIC(getpos);
-
->>>>>>> Made widget label updates thread safe.
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
 
 
 
@@ -204,23 +181,10 @@ static void gtk_rot_ctrl_destroy(GtkObject * object)
 {
     GtkRotCtrl     *ctrl = GTK_ROT_CTRL(object);
 
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
     if (ctrl->rotctl_thread != NULL)
     {
 
         g_mutex_lock(&ctrl->widgetsync);
-<<<<<<< HEAD
-=======
-=======
-    if (rotctl_thread != NULL)
-    {
-
-        g_mutex_lock(&widgetsync);
->>>>>>> Made widget label updates thread safe.
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
 
         ctrl->engaged = 0;
         setconfig(ctrl);
@@ -332,18 +296,8 @@ void gtk_rot_ctrl_update(GtkRotCtrl * ctrl, gdouble t)
 
 
     /* Enter critical section! */
-<<<<<<< HEAD
     g_mutex_lock(&ctrl->rot_ctrl_updatelock);
 
-=======
-<<<<<<< HEAD
-    g_mutex_lock(&ctrl->rot_ctrl_updatelock);
-
-=======
-    G_LOCK(rot_ctrl_updatelock);
-    
->>>>>>> Made widget label updates thread safe.
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
     ctrl->t = t;
 
     if (ctrl->target)
@@ -442,15 +396,7 @@ void gtk_rot_ctrl_update(GtkRotCtrl * ctrl, gdouble t)
     }
 
     /* Leave critical section! */
-<<<<<<< HEAD
     g_mutex_unlock(&ctrl->rot_ctrl_updatelock);
-=======
-<<<<<<< HEAD
-    g_mutex_unlock(&ctrl->rot_ctrl_updatelock);
-=======
-    G_UNLOCK(rot_ctrl_updatelock);
->>>>>>> Made widget label updates thread safe.
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
 }
 
 /** Select a satellite. */
@@ -1043,19 +989,11 @@ static gboolean rot_ctrl_timeout_cb(gpointer data)
 static gboolean get_pos(GtkRotCtrl * ctrl, gdouble * az, gdouble * el)
 {
     gchar          *buff, **vbuff;
-    gchar           buffback[256/*128*/];
+    gchar           buffback[128];
     gboolean        retcode;
 
     /* Enter critical section! TODO! */
-<<<<<<< HEAD
     g_mutex_lock(&ctrl->getpos);
-=======
-<<<<<<< HEAD
-    g_mutex_lock(&ctrl->getpos);
-=======
-    G_LOCK(getpos);
->>>>>>> Made widget label updates thread safe.
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
 
     if ((az == NULL) || (el == NULL))
     {
@@ -1100,18 +1038,8 @@ static gboolean get_pos(GtkRotCtrl * ctrl, gdouble * az, gdouble * el)
 
     g_free(buff);
 
-<<<<<<< HEAD
     /* Leave critical section! */
     g_mutex_unlock(&ctrl->getpos);
-=======
-<<<<<<< HEAD
-    /* Leave critical section! */
-    g_mutex_unlock(&ctrl->getpos);
-=======
-    /* Leave critical section! TODO! */
-    G_UNLOCK(getpos);
->>>>>>> Made widget label updates thread safe.
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
 
     return retcode;
 }
@@ -1130,24 +1058,14 @@ static gboolean get_pos(GtkRotCtrl * ctrl, gdouble * az, gdouble * el)
 static gboolean set_pos(GtkRotCtrl * ctrl, gdouble az, gdouble el)
 {
     gchar          *buff;
-    gchar           buffback[256/*128*/];
+    gchar           buffback[128];
     gchar           azstr[8], elstr[8];
     gboolean        retcode;
     gint            retval;
 
     /* Enter critical section! TODO! */
-<<<<<<< HEAD
     g_mutex_lock(&ctrl->setpos);
 
-=======
-<<<<<<< HEAD
-    g_mutex_lock(&ctrl->setpos);
-
-=======
-    G_LOCK(setpos);
-    
->>>>>>> Made widget label updates thread safe.
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
     /* send command */
     g_ascii_formatd(azstr, 8, "%7.2f", az);
     g_ascii_formatd(elstr, 8, "%7.2f", el);
@@ -1170,15 +1088,7 @@ static gboolean set_pos(GtkRotCtrl * ctrl, gdouble az, gdouble el)
     }
 
     /* Leave critical section! TODO! */
-<<<<<<< HEAD
     g_mutex_unlock(&ctrl->setpos);
-=======
-<<<<<<< HEAD
-    g_mutex_unlock(&ctrl->setpos);
-=======
-    G_UNLOCK(setpos);
->>>>>>> Made widget label updates thread safe.
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
 
     return (retcode);
 }
@@ -1538,17 +1448,7 @@ static void rotctrl_close(GtkRotCtrl * data)
 gpointer rotctl_run(gpointer data)
 {
     GtkRotCtrl     *ctrl = GTK_ROT_CTRL(data);
-<<<<<<< HEAD
     GtkRotCtrl     *t_ctrl = GTK_ROT_CTRL(data);
-=======
-<<<<<<< HEAD
-    GtkRotCtrl     *t_ctrl = GTK_ROT_CTRL(data);
-=======
-//    gdouble         rotaz = 0.0, rotel = 0.0;
-//    gdouble         setaz = 0.0, setel = 45.0;
-//    gchar          *text;
->>>>>>> Made widget label updates thread safe.
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
     gboolean        error = FALSE;
     sat_t           sat_working, *sat;
 
@@ -1558,24 +1458,11 @@ gpointer rotctl_run(gpointer data)
 
     while (1)
     {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
         t_ctrl = GTK_ROT_CTRL(g_async_queue_pop(ctrl->rotctlq));
         ctrl = t_ctrl;
         while (g_main_context_iteration(NULL, FALSE));
 
         if (t_ctrl == NULL)
-<<<<<<< HEAD
-=======
-=======
-        ctrl = GTK_ROT_CTRL(g_async_queue_pop(rotctlq));
-        while (g_main_context_iteration(NULL, FALSE));
-
-        if (ctrl == NULL)
->>>>>>> Made widget label updates thread safe.
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
         {
             sat_log_log(SAT_LOG_LEVEL_DEBUG,
                         _("%s:%s: ERROR: NO VALID ctrl-struct"), __FILE__,
@@ -1583,10 +1470,6 @@ gpointer rotctl_run(gpointer data)
             continue;
         }
 
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
         if (t_ctrl->engaged)
         {
             if (!t_ctrl->sock)
@@ -1686,12 +1569,6 @@ gpointer rotctl_run(gpointer data)
         }
 
         if ((t_ctrl->engaged) && (t_ctrl->conf != NULL))
-<<<<<<< HEAD
-=======
-=======
-	if (ctrl->engaged)
->>>>>>> Made widget label updates thread safe.
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
         {
             /* read back current value from device */
             if (get_pos(t_ctrl, &t_ctrl->rotaz, &t_ctrl->rotel))
@@ -1888,276 +1765,6 @@ gpointer rotctl_run(gpointer data)
                                                                    (t_ctrl->ElSet)));
             }
         }
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
-	else
-	{
-	    /* it's time to stop this thread */
-	    g_mutex_lock(&widgetsync);
-
-	    if (ctrl->sock > 0)
-	    {
-		rotctrl_close(ctrl);
-	    }
-
-	    if (ctrl->timerid)
-	    {
-		remove_timer(ctrl);
-	    }
-
-	    g_cond_signal(&widgetready);
-	    g_mutex_unlock(&widgetsync);
-	    break;
-	}
-
-	/* If we are tracking and the target satellite is within
-	   range, set the rotor position controller knob values to
-	   the target values. If the target satellite is out of range
-	   set the rotor controller to 0 deg El and to the Az where the
-	   target sat is expected to come up or where it last went down
-	*/
-	if (ctrl->tracking && ctrl->target)
-	{
-	    if (ctrl->target->el < 0.0)
-	    {
-		if (ctrl->pass != NULL)
-		{
-		    if (ctrl->t < ctrl->pass->aos)
-		    {
-			setaz = ctrl->pass->aos_az;
-			setel = 0;
-		    }
-		    else if (ctrl->t > ctrl->pass->los)
-		    {
-			setaz = ctrl->pass->los_az;
-			setel = 0;
-		    }
-		}
-	    }
-	    else
-	    {
-		setaz = ctrl->target->az;
-		setel = ctrl->target->el;
-	    }
-	    /* if this is a flipped pass and the rotor supports it */
-	    if ((ctrl->flipped) && (ctrl->conf->maxel >= 180.0))
-	    {
-		setel = 180 - setel;
-		if (setaz > 180)
-		    setaz -= 180;
-		else
-		    setaz += 180;
-
-		while (setaz > ctrl->conf->maxaz)
-		    setaz -= 360;
-
-		while (setaz < ctrl->conf->minaz)
-		    setaz += 360;
-	    }
-
-	    if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) && (setaz > 180.0))
-		setaz = setaz - 360.0;
-
-	    if (!(ctrl->engaged))
-	    {
-		gtk_rot_knob_set_value(GTK_ROT_KNOB(ctrl->AzSet), setaz);
-		gtk_rot_knob_set_value(GTK_ROT_KNOB(ctrl->ElSet), setel);
-	    }
-
-	}
-	else
-	{
-	    setaz = gtk_rot_knob_get_value(GTK_ROT_KNOB(ctrl->AzSet));
-	    setel = gtk_rot_knob_get_value(GTK_ROT_KNOB(ctrl->ElSet));
-	}
-
-	if ((ctrl->engaged) && (ctrl->conf != NULL))
-	{
-	    /* read back current value from device */
-	    if (get_pos(ctrl, &rotaz, &rotel))
-	    {
-		g_idle_add((GSourceFunc) update_display_widgets, ctrl);
-	    }
-	    else
-	    {
-		gtk_label_set_text(GTK_LABEL(ctrl->AzRead), _("ERROR"));
-		gtk_label_set_text(GTK_LABEL(ctrl->ElRead), _("ERROR"));
-		error = TRUE;
-
-		gtk_polar_plot_set_rotor_pos(GTK_POLAR_PLOT(ctrl->plot), -10.0,
-					     -10.0);
-	    }
-
-	    /* if tolerance exceeded */
-	    if ((fabs(setaz - rotaz) > ctrl->tolerance) ||
-		(fabs(setel - rotel) > ctrl->tolerance))
-	    {
-		if (ctrl->tracking)
-		{
-		    /* if we are in a pass try to lead the satellite 
-		       some so we are not always chasing it */
-		    if (ctrl->target && ctrl->target->el > 0.0)
-		    {
-			/* starting the rotator moving while we do some computation
-			 * can lead to errors later */
-			/* compute a time in the future when the position is 
-			   within tolerance so and send the rotor there.
-			*/
-
-			/* use a working copy so data does not get corrupted */
-			sat = memcpy(&(sat_working), ctrl->target, sizeof(sat_t));
-
-			/* compute az/el in the future that is past end of pass 
-			   or exceeds tolerance
-			*/
-			if (ctrl->pass)
-			{
-			    /* the next point is before the end of the pass 
-			       if there is one. */
-			    time_delta = ctrl->pass->los - ctrl->t;
-			}
-			else
-			{
-			    /* otherwise look 20 minutes into the future */
-			    time_delta = 1.0 / 72.0;
-			}
-
-			/* have a minimum time delta */
-			step_size = time_delta / 2.0;
-			if (step_size < ctrl->delay / 1000.0 / (secday))
-			{
-			    step_size = ctrl->delay / 1000.0 / (secday);
-			}
-			/* find a time when satellite is above horizon and at the 
-			   edge of tolerance. the final step size needs to be smaller
-			   than delay. otherwise the az/el could be further away than
-			   tolerance the next time we enter the loop and we end up 
-			   pushing ourselves away from the satellite.
-			*/
-			while (step_size > (ctrl->delay / 1000.0 / 4.0 / (secday)))
-			{
-			    predict_calc(sat, ctrl->qth, ctrl->t + time_delta);
-			    /*update sat->az and sat->el to account for flips and az range */
-			    if ((ctrl->flipped) && (ctrl->conf->maxel >= 180.0))
-			    {
-				sat->el = 180.0 - sat->el;
-				if (sat->az > 180.0)
-				    sat->az -= 180.0;
-				else
-				    sat->az += 180.0;
-			    }
-			    if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) &&
-				(sat->az > 180.0))
-			    {
-				sat->az = sat->az - 360.0;
-			    }
-			    if ((sat->el < 0.0) || (sat->el > 180.0) ||
-				(fabs(setaz - sat->az) > (ctrl->tolerance)) ||
-				(fabs(setel - sat->el) > (ctrl->tolerance)))
-			    {
-				time_delta -= step_size;
-			    }
-			    else
-			    {
-				time_delta += step_size;
-			    }
-			    step_size /= 2.0;
-			}
-			setel = sat->el;
-			if (setel < 0.0)
-			    setel = 0.0;
-
-			if (setel > 180.0)
-			    setel = 180.0;
-
-			setaz = sat->az;
-		    }
-		}
-
-		/* send controller values to rotator device */
-		/* this is the newly computed value which should be ahead of the current position */
-		if (!set_pos(ctrl, setaz, setel))
-		{
-		    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s:%d set_pos() error"),
-				__FILE__, __func__, __LINE__);
-		    error = TRUE;
-		}
-		else
-		{
-		    gtk_rot_knob_set_value(GTK_ROT_KNOB(ctrl->AzSet), setaz);
-		    gtk_rot_knob_set_value(GTK_ROT_KNOB(ctrl->ElSet), setel);
-		}
-	    }
-
-	    /* check error status */
-	    if (!error)
-	    {
-		/* reset error counter */
-		ctrl->errcnt = 0;
-	    }
-	    else
-	    {
-		if (ctrl->errcnt >= MAX_ERROR_COUNT)
-		{
-		    /* disengage device */
-		    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ctrl->LockBut),
-						 FALSE);
-		    ctrl->engaged = FALSE;
-		    sat_log_log(SAT_LOG_LEVEL_ERROR,
-				_
-				("%s: MAX_ERROR_COUNT (%d) reached. Disengaging device!"),
-				__func__, MAX_ERROR_COUNT);
-		    ctrl->errcnt = 0;
-		    //g_print ("ERROR. WROPS: %d   RDOPS: %d\n", ctrl->wrops, ctrl->rdops);
-		}
-		else
-		{
-		    /* increment error counter */
-		    ctrl->errcnt++;
-		    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s:%d set_pos() error #%d"),
-				__FILE__, __func__, __LINE__, ctrl->errcnt);
-		}
-	    }
-	}
-	else
-	{
-	    /* ensure rotor pos is not visible on plot */
-	    gtk_polar_plot_set_rotor_pos(GTK_POLAR_PLOT(ctrl->plot), -10.0, -10.0);
-	}
-
-
-	/* update target object on polar plot */
-	if (ctrl->target != NULL)
-	{
-	    gtk_polar_plot_set_target_pos(GTK_POLAR_PLOT(ctrl->plot),
-					  ctrl->target->az, ctrl->target->el);
-	}
-
-	/* update controller circle on polar plot */
-	if (ctrl->conf != NULL)
-	{
-	    if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) && (setaz < 0.0))
-	    {
-		gtk_polar_plot_set_ctrl_pos(GTK_POLAR_PLOT(ctrl->plot),
-					    gtk_rot_knob_get_value(GTK_ROT_KNOB
-								   (ctrl->AzSet)) +
-					    360.0,
-					    gtk_rot_knob_get_value(GTK_ROT_KNOB
-								   (ctrl->ElSet)));
-	    }
-	    else
-	    {
-		gtk_polar_plot_set_ctrl_pos(GTK_POLAR_PLOT(ctrl->plot),
-					    gtk_rot_knob_get_value(GTK_ROT_KNOB
-								   (ctrl->AzSet)),
-					    gtk_rot_knob_get_value(GTK_ROT_KNOB
-								   (ctrl->ElSet)));
-	    }
-	}
->>>>>>> Made widget label updates thread safe.
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
     }
 
     /* let's have a clean exit: */
@@ -2203,10 +1810,6 @@ void setconfig(gpointer data)
 
     if (ctrl != NULL)
     {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
         g_async_queue_push(ctrl->rotctlq, ctrl);
     }
 }
@@ -2233,38 +1836,6 @@ void           *update_display_widgets(gpointer data)
     {
         gtk_polar_plot_set_rotor_pos(GTK_POLAR_PLOT(ctrl->plot), ctrl->rotaz,
                                      ctrl->rotel);
-<<<<<<< HEAD
-=======
-=======
-        g_async_queue_push(rotctlq, ctrl);
->>>>>>> Made widget label updates thread safe.
-    }
-    return FALSE;
-}
-
-void *update_display_widgets(gpointer data)
-{
-    GtkRotCtrl     *ctrl = GTK_ROT_CTRL(data);
-    gchar          *text;
-
-    /* update display widgets */
-    text = g_strdup_printf("%.2f\302\260", rotaz);
-    gtk_label_set_text(GTK_LABEL(ctrl->AzRead), text);
-    g_free(text);
-    text = g_strdup_printf("%.2f\302\260", rotel);
-    gtk_label_set_text(GTK_LABEL(ctrl->ElRead), text);
-    g_free(text);
-
-    if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) && (rotaz < 0.0))
-    {
-	gtk_polar_plot_set_rotor_pos(GTK_POLAR_PLOT(ctrl->plot),
-				     rotaz + 360.0, rotel);
-    }
-    else
-    {
-	gtk_polar_plot_set_rotor_pos(GTK_POLAR_PLOT(ctrl->plot), rotaz,
-				     rotel);
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
     }
     return FALSE;
 }

--- a/src/gtk-rot-ctrl.c
+++ b/src/gtk-rot-ctrl.c
@@ -107,6 +107,25 @@ static inline void set_flipped_pass(GtkRotCtrl * ctrl);
 static GtkVBoxClass *parent_class = NULL;
 
 
+
+/* DL4PD: add thread for hamlib communication */
+gpointer        rotctl_run( gpointer data );
+static void     rotctrl_open(GtkRotCtrl * data);
+static void     rotctrl_close(GtkRotCtrl * data);
+static void     setconfig(gpointer data);
+static void     remove_timer(GtkRotCtrl * data);
+static void     start_timer(GtkRotCtrl * data);
+static GThread *rotctl_thread = NULL;
+
+static GMutex   widgetsync;
+static GCond    widgetready;
+static GAsyncQueue *rotctlq;
+
+G_LOCK_DEFINE_STATIC(writelock);
+
+
+
+
 GType gtk_rot_ctrl_get_type()
 {
     static GType    gtk_rot_ctrl_type = 0;
@@ -165,9 +184,30 @@ static void gtk_rot_ctrl_destroy(GtkObject * object)
 {
     GtkRotCtrl     *ctrl = GTK_ROT_CTRL(object);
 
+    /* DL4PD: MOVE from here... */
     /* stop timer */
-    if (ctrl->timerid > 0)
-        g_source_remove(ctrl->timerid);
+    //if (ctrl->timerid > 0)
+    //    g_source_remove(ctrl->timerid);
+
+    if (rotctl_thread != NULL)
+    {
+
+        sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: mutex lock..."),
+                    __FILE__, __func__);
+
+        g_mutex_lock(&widgetsync);
+
+        ctrl->engaged = 0;
+        setconfig(ctrl);
+
+        /* synchronization */
+        g_cond_wait(&widgetready, &widgetsync);
+        g_mutex_unlock(&widgetsync);
+        rotctl_thread = NULL;
+    }
+
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: free config..."),
+                __FILE__, __func__);
 
     /* free configuration */
     if (ctrl->conf != NULL)
@@ -249,10 +289,6 @@ GtkWidget      *gtk_rot_ctrl_new(GtkSatModule * module)
                      GTK_FILL | GTK_EXPAND, GTK_FILL | GTK_EXPAND, 0, 0);
 
     gtk_container_add(GTK_CONTAINER(widget), table);
-
-    GTK_ROT_CTRL(widget)->timerid = g_timeout_add(GTK_ROT_CTRL(widget)->delay,
-                                                  rot_ctrl_timeout_cb,
-                                                  GTK_ROT_CTRL(widget));
 
     if (module->target > 0)
         gtk_rot_ctrl_select_sat(GTK_ROT_CTRL(widget), module->target);
@@ -776,10 +812,17 @@ static void delay_changed_cb(GtkSpinButton * spin, gpointer data)
 
     ctrl->delay = (guint) gtk_spin_button_get_value(spin);
 
+    if (ctrl->engaged)
+    {
+        setconfig(ctrl);
+    }
+
+#if 0
     if (ctrl->timerid > 0)
         g_source_remove(ctrl->timerid);
 
     ctrl->timerid = g_timeout_add(ctrl->delay, rot_ctrl_timeout_cb, ctrl);
+#endif
 }
 
 /**
@@ -900,6 +943,10 @@ static void rot_locked_cb(GtkToggleButton * button, gpointer data)
         close_rotctld_socket(&(ctrl->sock));
         gtk_label_set_text(GTK_LABEL(ctrl->AzRead), "---");
         gtk_label_set_text(GTK_LABEL(ctrl->ElRead), "---");
+
+        /* DL4PD: stop worker thread... */
+        setconfig(ctrl);
+        rotctl_thread = NULL;
     }
     else
     {
@@ -914,9 +961,11 @@ static void rot_locked_cb(GtkToggleButton * button, gpointer data)
         }
         gtk_widget_set_sensitive(ctrl->DevSel, FALSE);
         ctrl->engaged = TRUE;
-        open_rotctld_socket(ctrl);
-        ctrl->wrops = 0;
-        ctrl->rdops = 0;
+
+        /* DL4PD: start worker thread... */
+        rotctlq = g_async_queue_new();
+        rotctl_thread = g_thread_new("rotctl_run", rotctl_run, ctrl);
+        setconfig(ctrl);
     }
 }
 
@@ -929,15 +978,6 @@ static void rot_locked_cb(GtkToggleButton * button, gpointer data)
 static gboolean rot_ctrl_timeout_cb(gpointer data)
 {
     GtkRotCtrl     *ctrl = GTK_ROT_CTRL(data);
-    gdouble         rotaz = 0.0, rotel = 0.0;
-    gdouble         setaz = 0.0, setel = 45.0;
-    gchar          *text;
-    gboolean        error = FALSE;
-    sat_t           sat_working, *sat;
-
-    /* parameters for path predictions */
-    gdouble         time_delta;
-    gdouble         step_size;
 
     if (g_mutex_trylock(&(ctrl->busy)) == FALSE)
     {
@@ -946,263 +986,9 @@ static gboolean rot_ctrl_timeout_cb(gpointer data)
         return TRUE;
     }
 
-    /* If we are tracking and the target satellite is within
-       range, set the rotor position controller knob values to
-       the target values. If the target satellite is out of range
-       set the rotor controller to 0 deg El and to the Az where the
-       target sat is expected to come up or where it last went down
-     */
-    if (ctrl->tracking && ctrl->target)
-    {
-        if (ctrl->target->el < 0.0)
-        {
-            if (ctrl->pass != NULL)
-            {
-                if (ctrl->t < ctrl->pass->aos)
-                {
-                    setaz = ctrl->pass->aos_az;
-                    setel = 0;
-                }
-                else if (ctrl->t > ctrl->pass->los)
-                {
-                    setaz = ctrl->pass->los_az;
-                    setel = 0;
-                }
-            }
-        }
-        else
-        {
-            setaz = ctrl->target->az;
-            setel = ctrl->target->el;
-        }
-        /* if this is a flipped pass and the rotor supports it */
-        if ((ctrl->flipped) && (ctrl->conf->maxel >= 180.0))
-        {
-            setel = 180 - setel;
-            if (setaz > 180)
-                setaz -= 180;
-            else
-                setaz += 180;
+    /* push event... */
+    setconfig(ctrl);
 
-            while (setaz > ctrl->conf->maxaz)
-                setaz -= 360;
-
-            while (setaz < ctrl->conf->minaz)
-                setaz += 360;
-        }
-
-        if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) && (setaz > 180.0))
-            setaz = setaz - 360.0;
-
-        if (!(ctrl->engaged))
-        {
-            gtk_rot_knob_set_value(GTK_ROT_KNOB(ctrl->AzSet), setaz);
-            gtk_rot_knob_set_value(GTK_ROT_KNOB(ctrl->ElSet), setel);
-        }
-
-    }
-    else
-    {
-        setaz = gtk_rot_knob_get_value(GTK_ROT_KNOB(ctrl->AzSet));
-        setel = gtk_rot_knob_get_value(GTK_ROT_KNOB(ctrl->ElSet));
-    }
-
-    if ((ctrl->engaged) && (ctrl->conf != NULL))
-    {
-        /* read back current value from device */
-        if (get_pos(ctrl, &rotaz, &rotel))
-        {
-            /* update display widgets */
-            text = g_strdup_printf("%.2f\302\260", rotaz);
-            gtk_label_set_text(GTK_LABEL(ctrl->AzRead), text);
-            g_free(text);
-            text = g_strdup_printf("%.2f\302\260", rotel);
-            gtk_label_set_text(GTK_LABEL(ctrl->ElRead), text);
-            g_free(text);
-
-            if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) && (rotaz < 0.0))
-            {
-                gtk_polar_plot_set_rotor_pos(GTK_POLAR_PLOT(ctrl->plot),
-                                             rotaz + 360.0, rotel);
-            }
-            else
-            {
-                gtk_polar_plot_set_rotor_pos(GTK_POLAR_PLOT(ctrl->plot), rotaz,
-                                             rotel);
-            }
-        }
-        else
-        {
-            gtk_label_set_text(GTK_LABEL(ctrl->AzRead), _("ERROR"));
-            gtk_label_set_text(GTK_LABEL(ctrl->ElRead), _("ERROR"));
-            error = TRUE;
-
-            gtk_polar_plot_set_rotor_pos(GTK_POLAR_PLOT(ctrl->plot), -10.0,
-                                         -10.0);
-        }
-
-        /* if tolerance exceeded */
-        if ((fabs(setaz - rotaz) > ctrl->tolerance) ||
-            (fabs(setel - rotel) > ctrl->tolerance))
-        {
-            if (ctrl->tracking)
-            {
-                /* if we are in a pass try to lead the satellite 
-                   some so we are not always chasing it */
-                if (ctrl->target && ctrl->target->el > 0.0)
-                {
-                    /* starting the rotator moving while we do some computation
-                     * can lead to errors later */
-                    /* compute a time in the future when the position is 
-                       within tolerance so and send the rotor there.
-                     */
-
-                    /* use a working copy so data does not get corrupted */
-                    sat = memcpy(&(sat_working), ctrl->target, sizeof(sat_t));
-
-                    /* compute az/el in the future that is past end of pass 
-                       or exceeds tolerance
-                     */
-                    if (ctrl->pass)
-                    {
-                        /* the next point is before the end of the pass 
-                           if there is one. */
-                        time_delta = ctrl->pass->los - ctrl->t;
-                    }
-                    else
-                    {
-                        /* otherwise look 20 minutes into the future */
-                        time_delta = 1.0 / 72.0;
-                    }
-
-                    /* have a minimum time delta */
-                    step_size = time_delta / 2.0;
-                    if (step_size < ctrl->delay / 1000.0 / (secday))
-                    {
-                        step_size = ctrl->delay / 1000.0 / (secday);
-                    }
-                    /* find a time when satellite is above horizon and at the 
-                       edge of tolerance. the final step size needs to be smaller
-                       than delay. otherwise the az/el could be further away than
-                       tolerance the next time we enter the loop and we end up 
-                       pushing ourselves away from the satellite.
-                     */
-                    while (step_size > (ctrl->delay / 1000.0 / 4.0 / (secday)))
-                    {
-                        predict_calc(sat, ctrl->qth, ctrl->t + time_delta);
-                        /*update sat->az and sat->el to account for flips and az range */
-                        if ((ctrl->flipped) && (ctrl->conf->maxel >= 180.0))
-                        {
-                            sat->el = 180.0 - sat->el;
-                            if (sat->az > 180.0)
-                                sat->az -= 180.0;
-                            else
-                                sat->az += 180.0;
-                        }
-                        if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) &&
-                            (sat->az > 180.0))
-                        {
-                            sat->az = sat->az - 360.0;
-                        }
-                        if ((sat->el < 0.0) || (sat->el > 180.0) ||
-                            (fabs(setaz - sat->az) > (ctrl->tolerance)) ||
-                            (fabs(setel - sat->el) > (ctrl->tolerance)))
-                        {
-                            time_delta -= step_size;
-                        }
-                        else
-                        {
-                            time_delta += step_size;
-                        }
-                        step_size /= 2.0;
-                    }
-                    setel = sat->el;
-                    if (setel < 0.0)
-                        setel = 0.0;
-
-                    if (setel > 180.0)
-                        setel = 180.0;
-
-                    setaz = sat->az;
-                }
-            }
-
-            /* send controller values to rotator device */
-            /* this is the newly computed value which should be ahead of the current position */
-            if (!set_pos(ctrl, setaz, setel))
-            {
-                error = TRUE;
-            }
-            else
-            {
-                gtk_rot_knob_set_value(GTK_ROT_KNOB(ctrl->AzSet), setaz);
-                gtk_rot_knob_set_value(GTK_ROT_KNOB(ctrl->ElSet), setel);
-            }
-        }
-
-        /* check error status */
-        if (!error)
-        {
-            /* reset error counter */
-            ctrl->errcnt = 0;
-        }
-        else
-        {
-            if (ctrl->errcnt >= MAX_ERROR_COUNT)
-            {
-                /* disengage device */
-                gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ctrl->LockBut),
-                                             FALSE);
-                ctrl->engaged = FALSE;
-                sat_log_log(SAT_LOG_LEVEL_ERROR,
-                            _
-                            ("%s: MAX_ERROR_COUNT (%d) reached. Disengaging device!"),
-                            __func__, MAX_ERROR_COUNT);
-                ctrl->errcnt = 0;
-                //g_print ("ERROR. WROPS: %d   RDOPS: %d\n", ctrl->wrops, ctrl->rdops);
-            }
-            else
-            {
-                /* increment error counter */
-                ctrl->errcnt++;
-            }
-        }
-    }
-    else
-    {
-        /* ensure rotor pos is not visible on plot */
-        gtk_polar_plot_set_rotor_pos(GTK_POLAR_PLOT(ctrl->plot), -10.0, -10.0);
-    }
-
-
-    /* update target object on polar plot */
-    if (ctrl->target != NULL)
-    {
-        gtk_polar_plot_set_target_pos(GTK_POLAR_PLOT(ctrl->plot),
-                                      ctrl->target->az, ctrl->target->el);
-    }
-
-    /* update controller circle on polar plot */
-    if (ctrl->conf != NULL)
-    {
-        if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) && (setaz < 0.0))
-        {
-            gtk_polar_plot_set_ctrl_pos(GTK_POLAR_PLOT(ctrl->plot),
-                                        gtk_rot_knob_get_value(GTK_ROT_KNOB
-                                                               (ctrl->AzSet)) +
-                                        360.0,
-                                        gtk_rot_knob_get_value(GTK_ROT_KNOB
-                                                               (ctrl->ElSet)));
-        }
-        else
-        {
-            gtk_polar_plot_set_ctrl_pos(GTK_POLAR_PLOT(ctrl->plot),
-                                        gtk_rot_knob_get_value(GTK_ROT_KNOB
-                                                               (ctrl->AzSet)),
-                                        gtk_rot_knob_get_value(GTK_ROT_KNOB
-                                                               (ctrl->ElSet)));
-        }
-    }
     g_mutex_unlock(&(ctrl->busy));
 
     return TRUE;
@@ -1219,7 +1005,7 @@ static gboolean rot_ctrl_timeout_cb(gpointer data)
 static gboolean get_pos(GtkRotCtrl * ctrl, gdouble * az, gdouble * el)
 {
     gchar          *buff, **vbuff;
-    gchar           buffback[128];
+    gchar           buffback[256/*128*/];
     gboolean        retcode;
 
     if ((az == NULL) || (el == NULL))
@@ -1229,9 +1015,15 @@ static gboolean get_pos(GtkRotCtrl * ctrl, gdouble * az, gdouble * el)
         return FALSE;
     }
 
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: <precmd>"),
+		__FILE__, __func__);
+
     /* send command */
     buff = g_strdup_printf("p\x0a");
     retcode = send_rotctld_command(ctrl, buff, buffback, 128);
+
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: <postcmd>"),
+		__FILE__, __func__);
 
     /* try to read answer */
     if (retcode)
@@ -1263,7 +1055,13 @@ static gboolean get_pos(GtkRotCtrl * ctrl, gdouble * az, gdouble * el)
         }
     }
 
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: <prefree>"),
+		__FILE__, __func__);
+
     g_free(buff);
+
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: <postfree>"),
+		__FILE__, __func__);
 
     return retcode;
 }
@@ -1294,7 +1092,13 @@ static gboolean set_pos(GtkRotCtrl * ctrl, gdouble az, gdouble el)
 
     retcode = send_rotctld_command(ctrl, buff, buffback, 128);
 
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: <prefree>"),
+		__FILE__, __func__);
+
     g_free(buff);
+
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: <postfree>"),
+		__FILE__, __func__);
 
     if (retcode == TRUE)
     {
@@ -1354,8 +1158,13 @@ static void update_count_down(GtkRotCtrl * ctrl, gdouble t)
 
     gtk_label_set_text(GTK_LABEL(ctrl->SatCnt), buff);
 
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: <prefree>"),
+		__FILE__, __func__);
+
     g_free(buff);
 
+    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: <postfree>"),
+		__FILE__, __func__);
 }
 
 /** Check that we have at least one .rot file */
@@ -1484,6 +1293,9 @@ gboolean send_rotctld_command(GtkRotCtrl * ctrl, gchar * buff, gchar * buffout,
     gint            written;
     gint            size;
 
+    /* Enter critical section! */
+    G_LOCK(writelock);
+
     /* added by Marcel Cimander; win32 newline -> \10\13 */
 #ifdef WIN32
     size = strlen(buff) - 1;
@@ -1536,6 +1348,9 @@ gboolean send_rotctld_command(GtkRotCtrl * ctrl, gchar * buff, gchar * buffout,
 
     ctrl->wrops++;
 
+    /* Leave critical section! */
+    G_UNLOCK(writelock);
+    
     return TRUE;
 }
 
@@ -1639,4 +1454,409 @@ static inline void set_flipped_pass(GtkRotCtrl * ctrl)
     if (ctrl->conf && ctrl->pass)
         ctrl->flipped = is_flipped_pass(ctrl->pass, ctrl->conf->aztype,
                                         ctrl->conf->azstoppos);
+}
+
+/* rotctrl_close() */
+static void rotctrl_open(GtkRotCtrl * data)
+{
+    GtkRotCtrl     *ctrl = GTK_ROT_CTRL(data);
+
+    /* DL4PD: MOVE from here... */
+    open_rotctld_socket(ctrl);
+    ctrl->wrops = 0;
+    ctrl->rdops = 0;
+}
+
+/* rotctrl_open() */
+static void rotctrl_close(GtkRotCtrl * data)
+{
+    GtkRotCtrl     *ctrl = GTK_ROT_CTRL(data);
+
+    remove_timer(ctrl);
+    close_rotctld_socket(&(ctrl->sock));
+}
+
+gpointer rotctl_run(gpointer data)
+{
+    static GMutex   rotctl_in_progress;
+    GtkRotCtrl     *ctrl = GTK_ROT_CTRL(data);
+    gdouble         rotaz = 0.0, rotel = 0.0;
+    gdouble         setaz = 0.0, setel = 45.0;
+    gchar          *text;
+    gboolean        error = FALSE;
+    sat_t           sat_working, *sat;
+
+    /* parameters for path predictions */
+    gdouble         time_delta;
+    gdouble         step_size;
+
+    if (g_mutex_trylock(&rotctl_in_progress) == FALSE)
+    {
+        sat_log_log(SAT_LOG_LEVEL_ERROR,
+                    _("%s:%s: rotctl_run already running. Aborting."),
+                    __FILE__, __func__);
+
+        return NULL;
+    }
+
+
+    while (1)
+    {
+        sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: ...idle..."),
+                    __FILE__, __func__);
+
+        ctrl = GTK_ROT_CTRL(g_async_queue_pop(rotctlq));
+        while (g_main_context_iteration(NULL, FALSE));
+
+        sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: pop event..."),
+                    __FILE__, __func__);
+
+        if (ctrl == NULL)
+        {
+            sat_log_log(SAT_LOG_LEVEL_DEBUG,
+                        _("%s:%s: ERROR: NO VALID ctrl-struct"), __FILE__,
+                        __func__);
+            continue;
+        }
+
+        sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: ...[@%p] busy..."),
+                    __FILE__, __func__, g_thread_self());
+
+	if (ctrl->engaged)
+        {
+            if (!ctrl->sock)
+            {
+                rotctrl_open(ctrl);
+            }
+
+            if (!ctrl->timerid)
+            {
+                start_timer(ctrl);
+            }
+        }
+	else
+	{
+	    g_mutex_lock(&widgetsync);
+
+	    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: [@%p] tidy up..."),
+			__FILE__, __func__, g_thread_self());
+
+	    if (ctrl->sock > 0)
+	    {
+		rotctrl_close(ctrl);
+	    }
+
+	    if (ctrl->timerid)
+	    {
+		remove_timer(ctrl);
+	    }
+
+	    sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: mutex unlock..."),
+			__FILE__, __func__);
+
+	    g_cond_signal(&widgetready);
+	    g_mutex_unlock(&widgetsync);
+	    break;
+	}
+
+	/* If we are tracking and the target satellite is within
+	   range, set the rotor position controller knob values to
+	   the target values. If the target satellite is out of range
+	   set the rotor controller to 0 deg El and to the Az where the
+	   target sat is expected to come up or where it last went down
+	*/
+	if (ctrl->tracking && ctrl->target)
+	{
+	    if (ctrl->target->el < 0.0)
+	    {
+		if (ctrl->pass != NULL)
+		{
+		    if (ctrl->t < ctrl->pass->aos)
+		    {
+			setaz = ctrl->pass->aos_az;
+			setel = 0;
+		    }
+		    else if (ctrl->t > ctrl->pass->los)
+		    {
+			setaz = ctrl->pass->los_az;
+			setel = 0;
+		    }
+		}
+	    }
+	    else
+	    {
+		setaz = ctrl->target->az;
+		setel = ctrl->target->el;
+	    }
+	    /* if this is a flipped pass and the rotor supports it */
+	    if ((ctrl->flipped) && (ctrl->conf->maxel >= 180.0))
+	    {
+		setel = 180 - setel;
+		if (setaz > 180)
+		    setaz -= 180;
+		else
+		    setaz += 180;
+
+		while (setaz > ctrl->conf->maxaz)
+		    setaz -= 360;
+
+		while (setaz < ctrl->conf->minaz)
+		    setaz += 360;
+	    }
+
+	    if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) && (setaz > 180.0))
+		setaz = setaz - 360.0;
+
+	    if (!(ctrl->engaged))
+	    {
+		gtk_rot_knob_set_value(GTK_ROT_KNOB(ctrl->AzSet), setaz);
+		gtk_rot_knob_set_value(GTK_ROT_KNOB(ctrl->ElSet), setel);
+	    }
+
+	}
+	else
+	{
+	    setaz = gtk_rot_knob_get_value(GTK_ROT_KNOB(ctrl->AzSet));
+	    setel = gtk_rot_knob_get_value(GTK_ROT_KNOB(ctrl->ElSet));
+	}
+
+	if ((ctrl->engaged) && (ctrl->conf != NULL))
+	{
+	    /* read back current value from device */
+	    if (get_pos(ctrl, &rotaz, &rotel))
+	    {
+		/* update display widgets */
+		text = g_strdup_printf("%.2f\302\260", rotaz);
+		gtk_label_set_text(GTK_LABEL(ctrl->AzRead), text);
+		g_free(text);
+		text = g_strdup_printf("%.2f\302\260", rotel);
+		gtk_label_set_text(GTK_LABEL(ctrl->ElRead), text);
+		g_free(text);
+
+		if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) && (rotaz < 0.0))
+		{
+		    gtk_polar_plot_set_rotor_pos(GTK_POLAR_PLOT(ctrl->plot),
+						 rotaz + 360.0, rotel);
+		}
+		else
+		{
+		    gtk_polar_plot_set_rotor_pos(GTK_POLAR_PLOT(ctrl->plot), rotaz,
+						 rotel);
+		}
+	    }
+	    else
+	    {
+		gtk_label_set_text(GTK_LABEL(ctrl->AzRead), _("ERROR"));
+		gtk_label_set_text(GTK_LABEL(ctrl->ElRead), _("ERROR"));
+		error = TRUE;
+
+		gtk_polar_plot_set_rotor_pos(GTK_POLAR_PLOT(ctrl->plot), -10.0,
+					     -10.0);
+	    }
+
+	    /* if tolerance exceeded */
+	    if ((fabs(setaz - rotaz) > ctrl->tolerance) ||
+		(fabs(setel - rotel) > ctrl->tolerance))
+	    {
+		if (ctrl->tracking)
+		{
+		    /* if we are in a pass try to lead the satellite 
+		       some so we are not always chasing it */
+		    if (ctrl->target && ctrl->target->el > 0.0)
+		    {
+			/* starting the rotator moving while we do some computation
+			 * can lead to errors later */
+			/* compute a time in the future when the position is 
+			   within tolerance so and send the rotor there.
+			*/
+
+			/* use a working copy so data does not get corrupted */
+			sat = memcpy(&(sat_working), ctrl->target, sizeof(sat_t));
+
+			/* compute az/el in the future that is past end of pass 
+			   or exceeds tolerance
+			*/
+			if (ctrl->pass)
+			{
+			    /* the next point is before the end of the pass 
+			       if there is one. */
+			    time_delta = ctrl->pass->los - ctrl->t;
+			}
+			else
+			{
+			    /* otherwise look 20 minutes into the future */
+			    time_delta = 1.0 / 72.0;
+			}
+
+			/* have a minimum time delta */
+			step_size = time_delta / 2.0;
+			if (step_size < ctrl->delay / 1000.0 / (secday))
+			{
+			    step_size = ctrl->delay / 1000.0 / (secday);
+			}
+			/* find a time when satellite is above horizon and at the 
+			   edge of tolerance. the final step size needs to be smaller
+			   than delay. otherwise the az/el could be further away than
+			   tolerance the next time we enter the loop and we end up 
+			   pushing ourselves away from the satellite.
+			*/
+			while (step_size > (ctrl->delay / 1000.0 / 4.0 / (secday)))
+			{
+			    predict_calc(sat, ctrl->qth, ctrl->t + time_delta);
+			    /*update sat->az and sat->el to account for flips and az range */
+			    if ((ctrl->flipped) && (ctrl->conf->maxel >= 180.0))
+			    {
+				sat->el = 180.0 - sat->el;
+				if (sat->az > 180.0)
+				    sat->az -= 180.0;
+				else
+				    sat->az += 180.0;
+			    }
+			    if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) &&
+				(sat->az > 180.0))
+			    {
+				sat->az = sat->az - 360.0;
+			    }
+			    if ((sat->el < 0.0) || (sat->el > 180.0) ||
+				(fabs(setaz - sat->az) > (ctrl->tolerance)) ||
+				(fabs(setel - sat->el) > (ctrl->tolerance)))
+			    {
+				time_delta -= step_size;
+			    }
+			    else
+			    {
+				time_delta += step_size;
+			    }
+			    step_size /= 2.0;
+			}
+			setel = sat->el;
+			if (setel < 0.0)
+			    setel = 0.0;
+
+			if (setel > 180.0)
+			    setel = 180.0;
+
+			setaz = sat->az;
+		    }
+		}
+
+		/* send controller values to rotator device */
+		/* this is the newly computed value which should be ahead of the current position */
+		if (!set_pos(ctrl, setaz, setel))
+		{
+		    error = TRUE;
+		}
+		else
+		{
+		    gtk_rot_knob_set_value(GTK_ROT_KNOB(ctrl->AzSet), setaz);
+		    gtk_rot_knob_set_value(GTK_ROT_KNOB(ctrl->ElSet), setel);
+		}
+	    }
+
+	    /* check error status */
+	    if (!error)
+	    {
+		/* reset error counter */
+		ctrl->errcnt = 0;
+	    }
+	    else
+	    {
+		if (ctrl->errcnt >= MAX_ERROR_COUNT)
+		{
+		    /* disengage device */
+		    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ctrl->LockBut),
+						 FALSE);
+		    ctrl->engaged = FALSE;
+		    sat_log_log(SAT_LOG_LEVEL_ERROR,
+				_
+				("%s: MAX_ERROR_COUNT (%d) reached. Disengaging device!"),
+				__func__, MAX_ERROR_COUNT);
+		    ctrl->errcnt = 0;
+		    //g_print ("ERROR. WROPS: %d   RDOPS: %d\n", ctrl->wrops, ctrl->rdops);
+		}
+		else
+		{
+		    /* increment error counter */
+		    ctrl->errcnt++;
+		}
+	    }
+	}
+	else
+	{
+	    /* ensure rotor pos is not visible on plot */
+	    gtk_polar_plot_set_rotor_pos(GTK_POLAR_PLOT(ctrl->plot), -10.0, -10.0);
+	}
+
+
+	/* update target object on polar plot */
+	if (ctrl->target != NULL)
+	{
+	    gtk_polar_plot_set_target_pos(GTK_POLAR_PLOT(ctrl->plot),
+					  ctrl->target->az, ctrl->target->el);
+	}
+
+	/* update controller circle on polar plot */
+	if (ctrl->conf != NULL)
+	{
+	    if ((ctrl->conf->aztype == ROT_AZ_TYPE_180) && (setaz < 0.0))
+	    {
+		gtk_polar_plot_set_ctrl_pos(GTK_POLAR_PLOT(ctrl->plot),
+					    gtk_rot_knob_get_value(GTK_ROT_KNOB
+								   (ctrl->AzSet)) +
+					    360.0,
+					    gtk_rot_knob_get_value(GTK_ROT_KNOB
+								   (ctrl->ElSet)));
+	    }
+	    else
+	    {
+		gtk_polar_plot_set_ctrl_pos(GTK_POLAR_PLOT(ctrl->plot),
+					    gtk_rot_knob_get_value(GTK_ROT_KNOB
+								   (ctrl->AzSet)),
+					    gtk_rot_knob_get_value(GTK_ROT_KNOB
+								   (ctrl->ElSet)));
+	    }
+	}
+    }
+
+    g_mutex_unlock(&rotctl_in_progress);
+    return NULL;
+}
+
+void start_timer(GtkRotCtrl * data)
+{
+    GtkRotCtrl     *ctrl = GTK_ROT_CTRL(data);
+
+    /* DL4PD: start timeout timer here ("Cycle")! */
+    if (ctrl->timerid > 0)
+        g_source_remove(ctrl->timerid);
+
+    ctrl->timerid =
+        gdk_threads_add_timeout(ctrl->delay, rot_ctrl_timeout_cb, ctrl);
+
+    sat_log_log(SAT_LOG_LEVEL_DEBUG,
+                _("%s:%s: [@%p] added timer (id:%d) with delay %d"), __FILE__,
+                __func__, g_thread_self(), ctrl->timerid, ctrl->delay);
+}
+
+void remove_timer(GtkRotCtrl * data)
+{
+    GtkRotCtrl     *ctrl = GTK_ROT_CTRL(data);
+
+    /* stop timer */
+    if (ctrl->timerid > 0)
+        g_source_remove(ctrl->timerid);
+    ctrl->timerid = 0;
+}
+
+void setconfig(gpointer data)
+{
+    /* something has changed... */
+    GtkRotCtrl     *ctrl = GTK_ROT_CTRL(data);
+
+    if (ctrl != NULL)
+    {
+        sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s:%s: push event..."),
+                    __FILE__, __func__);
+        g_async_queue_push(rotctlq, ctrl);
+    }
 }

--- a/src/gtk-rot-ctrl.h
+++ b/src/gtk-rot-ctrl.h
@@ -94,6 +94,22 @@ struct _gtk_rot_ctrl {
     /* debug related */
     guint           wrops;
     guint           rdops;
+
+    /* DL4PD */
+    /* threads related stuff */
+    /* add mutexes etc, to make threads reentrant! */
+    GMutex          writelock;           /*!< Mutex for blocking write operation */
+    GMutex          rot_ctrl_updatelock; /*!< Mutex wile updating widgets etc */
+    GMutex          setpos;
+    GMutex          getpos;
+    GMutex          widgetsync;          /*!< Mutex used while leaving (sync stuff) */
+    GCond           widgetready;         /*!< Condition when work is done (sync stuff) */
+    GAsyncQueue    *rotctlq;             /*!< Message queue to indicate something has changed */
+    GThread        *rotctl_thread;       /*!< Pointer to current rigctl-thread */
+    gdouble         rotaz;               /*!< current azimuth of rotor */
+    gdouble         rotel;               /*!< current elevation of rotor */
+    gdouble         setaz;               /*!< set azimuth */
+    gdouble         setel;               /*!< set elevation */
 };
 
 struct _GtkRotCtrlClass {

--- a/src/gtk-rot-ctrl.h
+++ b/src/gtk-rot-ctrl.h
@@ -37,8 +37,8 @@
 #include "sgpsdp/sgp4sdp4.h"
 
 #ifdef __cplusplus
-extern          "C" {
-#endif                          /* __cplusplus */
+extern "C" {
+#endif /* __cplusplus */
 
 #define GTK_TYPE_ROT_CTRL          (gtk_rot_ctrl_get_type ())
 #define GTK_ROT_CTRL(obj)          G_TYPE_CHECK_INSTANCE_CAST (obj,\
@@ -51,7 +51,6 @@ extern          "C" {
 
 #define IS_GTK_ROT_CTRL(obj)       G_TYPE_CHECK_INSTANCE_TYPE (obj, gtk_rot_ctrl_get_type ())
 
-<<<<<<< HEAD
 typedef struct _gtk_rot_ctrl GtkRotCtrl;
 typedef struct _GtkRotCtrlClass GtkRotCtrlClass;
 
@@ -121,79 +120,9 @@ GType           gtk_rot_ctrl_get_type(void);
 GtkWidget      *gtk_rot_ctrl_new(GtkSatModule * module);
 void            gtk_rot_ctrl_update(GtkRotCtrl * ctrl, gdouble t);
 void            gtk_rot_ctrl_select_sat(GtkRotCtrl * ctrl, gint catnum);
-=======
-    typedef struct _gtk_rot_ctrl GtkRotCtrl;
-    typedef struct _GtkRotCtrlClass GtkRotCtrlClass;
-
-    struct _gtk_rot_ctrl {
-        GtkVBox         vbox;
-
-        /* Azimuth widgets */
-        GtkWidget      *AzSat, *AzSet, *AzRead, *AzDevSel;
-
-        /* Elevation widgets */
-        GtkWidget      *ElSat, *ElSet, *ElRead, *ElDevSel, *ElDev;
-
-        /* other widgets */
-        GtkWidget      *SatSel;
-        GtkWidget      *SatCnt;
-        GtkWidget      *DevSel;
-        GtkWidget      *plot;   /*!< Polar plot widget */
-        GtkWidget      *LockBut;
-
-        rotor_conf_t   *conf;
-        gdouble         t;      /*!< Time when sat data last has been updated. */
-
-        /* satellites */
-        GSList         *sats;   /*!< List of sats in parent module */
-        sat_t          *target; /*!< Target satellite */
-        pass_t         *pass;   /*!< Next pass of target satellite */
-        qth_t          *qth;    /*!< The QTH for this module */
-        gboolean        flipped;        /*!< Whether the current pass loaded is a flip pass or not */
-
-        guint           delay;  /*!< Timeout delay. */
-        guint           timerid;        /*!< Timer ID */
-        gdouble         tolerance;      /*!< Error tolerance */
-
-        gboolean        tracking;       /*!< Flag set when we are tracking a target. */
-        GMutex          busy;   /*!< Flag set when control algorithm is busy. */
-        gboolean        engaged;        /*!< Flag indicating that rotor device is engaged. */
-
-        gint            errcnt; /*!< Error counter. */
-        gint            sock;   /*!< socket for connecting to rotctld. */
-
-        /* debug related */
-        guint           wrops;
-        guint           rdops;
-
-        /* DL4PD */
-        /* threads related stuff */
-        /* add mutexes etc, to make threads reentrant! */
-        GMutex          writelock;      /*!< Mutex for blocking write operation */
-        GMutex          rot_ctrl_updatelock;    /*!< Mutex wile updating widgets etc */
-        GMutex          setpos;
-        GMutex          getpos;
-        GMutex          widgetsync;     /*!< Mutex used while leaving (sync stuff) */
-        GCond           widgetready;    /*!< Condition when work is done (sync stuff) */
-        GAsyncQueue    *rotctlq;        /*!< Message queue to indicate something has changed */
-        GThread        *rotctl_thread;  /*!< Pointer to current rigctl-thread */
-        gdouble         rotaz;  /*!< current azimuth of rotor */
-        gdouble         rotel;  /*!< current elevation of rotor */
-        gdouble         setaz;  /*!< set azimuth */
-        gdouble         setel;  /*!< set elevation */
-    };
-
-    struct _GtkRotCtrlClass {
-        GtkVBoxClass    parent_class;
-    };
-
-    GType           gtk_rot_ctrl_get_type(void);
-    GtkWidget      *gtk_rot_ctrl_new(GtkSatModule * module);
-    void            gtk_rot_ctrl_update(GtkRotCtrl * ctrl, gdouble t);
-    void            gtk_rot_ctrl_select_sat(GtkRotCtrl * ctrl, gint catnum);
->>>>>>> 7c52fcf638ba14df5b628187cd791c77a9b2820d
 
 #ifdef __cplusplus
 }
-#endif                          /* __cplusplus */
-#endif                          /* __GTK_ROT_CTRL_H__ */
+#endif /* __cplusplus */
+
+#endif /* __GTK_ROT_CTRL_H__ */

--- a/src/gtk-rot-knob.c
+++ b/src/gtk-rot-knob.c
@@ -38,93 +38,94 @@
 #include <math.h>
 #include "gtk-rot-knob.h"
 #ifdef HAVE_CONFIG_H
-#include <build-config.h>
+#  include <build-config.h>
 #endif
 
 
 #define FMTSTR "<span size='xx-large'>%c</span>"
 
 
-static void     gtk_rot_knob_class_init(GtkRotKnobClass * class);
-static void     gtk_rot_knob_init(GtkRotKnob * list);
-static void     gtk_rot_knob_destroy(GtkObject * object);
+static void gtk_rot_knob_class_init (GtkRotKnobClass *class);
+static void gtk_rot_knob_init       (GtkRotKnob      *list);
+static void gtk_rot_knob_destroy    (GtkObject       *object);
 
-static void    *gtk_rot_knob_update(GtkRotKnob * knob);
+static void *gtk_rot_knob_update     (GtkRotKnob *knob);
 
-static void     button_clicked_cb(GtkWidget * button, gpointer data);
-static gboolean on_button_press(GtkWidget * digit, GdkEventButton * event,
-                                gpointer data);
-static gboolean on_button_scroll(GtkWidget * digit, GdkEventScroll * event,
-                                 gpointer data);
+static void button_clicked_cb (GtkWidget *button, gpointer data);
+static gboolean on_button_press  (GtkWidget *digit, GdkEventButton *event, gpointer data);
+static gboolean on_button_scroll (GtkWidget *digit, GdkEventScroll *event, gpointer data);
 
 static GtkHBoxClass *parent_class = NULL;
 
 G_LOCK_DEFINE_STATIC(updatelock);
 
 /** \brief Convert digit index (in the digit array) to amount of change. */
-const gdouble   INDEX_TO_DELTA[] = { 0.0, 100.0, 10.0, 1.0, 0.0, 0.1, 0.01 };
+const gdouble INDEX_TO_DELTA[] = {0.0, 100.0, 10.0, 1.0, 0.0, 0.1, 0.01};
+        
 
-
-GType gtk_rot_knob_get_type()
+GType
+gtk_rot_knob_get_type ()
 {
-    static GType    gtk_rot_knob_type = 0;
+     static GType gtk_rot_knob_type = 0;
 
-    if (!gtk_rot_knob_type)
-    {
+     if (!gtk_rot_knob_type) {
 
-        static const GTypeInfo gtk_rot_knob_info = {
-            sizeof(GtkRotKnobClass),
-            NULL,               /* base_init */
-            NULL,               /* base_finalize */
-            (GClassInitFunc) gtk_rot_knob_class_init,
-            NULL,               /* class_finalize */
-            NULL,               /* class_data */
-            sizeof(GtkRotKnob),
-            5,                  /* n_preallocs */
-            (GInstanceInitFunc) gtk_rot_knob_init,
-            NULL
-        };
+          static const GTypeInfo gtk_rot_knob_info = {
+               sizeof (GtkRotKnobClass),
+               NULL,  /* base_init */
+               NULL,  /* base_finalize */
+               (GClassInitFunc) gtk_rot_knob_class_init,
+               NULL,  /* class_finalize */
+               NULL,  /* class_data */
+               sizeof (GtkRotKnob),
+               5,     /* n_preallocs */
+               (GInstanceInitFunc) gtk_rot_knob_init,
+               NULL
+          };
 
-        gtk_rot_knob_type = g_type_register_static(GTK_TYPE_VBOX,
-                                                   "GtkRotKnob",
-                                                   &gtk_rot_knob_info, 0);
-    }
+          gtk_rot_knob_type = g_type_register_static (GTK_TYPE_VBOX,
+                                                                "GtkRotKnob",
+                                                                 &gtk_rot_knob_info,
+                                                                 0);
+     }
 
-    return gtk_rot_knob_type;
+     return gtk_rot_knob_type;
 }
 
 
-static void gtk_rot_knob_class_init(GtkRotKnobClass * class)
+static void
+gtk_rot_knob_class_init (GtkRotKnobClass *class)
 {
-    /*GObjectClass      *gobject_class; */
-    GtkObjectClass *object_class;
+    /*GObjectClass      *gobject_class;*/
+    GtkObjectClass    *object_class;
+    /*GtkWidgetClass    *widget_class;*/
+    /*GtkContainerClass *container_class;*/
+    
+    /*gobject_class   = G_OBJECT_CLASS (class);*/
+    object_class    = (GtkObjectClass*) class;
+    /*widget_class    = (GtkWidgetClass*) class;*/
+    /*container_class = (GtkContainerClass*) class;*/
+    
+     parent_class = g_type_class_peek_parent (class);
 
-    /*GtkWidgetClass    *widget_class; */
-    /*GtkContainerClass *container_class; */
-
-    /*gobject_class   = G_OBJECT_CLASS (class); */
-    object_class = (GtkObjectClass *) class;
-    /*widget_class    = (GtkWidgetClass*) class; */
-    /*container_class = (GtkContainerClass*) class; */
-
-    parent_class = g_type_class_peek_parent(class);
-
-    object_class->destroy = gtk_rot_knob_destroy;
-
+     object_class->destroy = gtk_rot_knob_destroy;
+ 
 }
 
 
 
-static void gtk_rot_knob_init(GtkRotKnob * knob)
+static void
+gtk_rot_knob_init (GtkRotKnob *knob)
 {
-
-    (void)knob;                 /* avoid unused parameter warning */
-
+   
+    (void) knob; /* avoid unused parameter warning */
+    
 }
 
-static void gtk_rot_knob_destroy(GtkObject * object)
+static void
+gtk_rot_knob_destroy (GtkObject *object)
 {
-    (*GTK_OBJECT_CLASS(parent_class)->destroy) (object);
+     (* GTK_OBJECT_CLASS (parent_class)->destroy) (object);
 }
 
 
@@ -136,178 +137,175 @@ static void gtk_rot_knob_destroy(GtkObject * object)
  * \return A new rotor control widget.
  * 
  */
-GtkWidget      *gtk_rot_knob_new(gdouble min, gdouble max, gdouble val)
+GtkWidget *
+gtk_rot_knob_new (gdouble min, gdouble max, gdouble val)
 {
-    GtkWidget      *widget;
-    GtkWidget      *table;
-    GtkWidget      *label;
-    guint           i;
+    GtkWidget *widget;
+    GtkWidget *table;
+    GtkWidget *label;
+    guint i;
 
-    widget = g_object_new(GTK_TYPE_ROT_KNOB, NULL);
+     widget = g_object_new (GTK_TYPE_ROT_KNOB, NULL);
 
     GTK_ROT_KNOB(widget)->min = min;
     GTK_ROT_KNOB(widget)->max = max;
     GTK_ROT_KNOB(widget)->value = val;
 
     /* create table */
-    table = gtk_table_new(3, 8, FALSE);
+    table = gtk_table_new (3, 8, FALSE);
 
     /* create buttons */
     /* +100 deg */
-    GTK_ROT_KNOB(widget)->buttons[0] = gtk_button_new();
-    gtk_container_add(GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[0]),
-                      gtk_arrow_new(GTK_ARROW_UP, GTK_SHADOW_NONE));
-    gtk_button_set_relief(GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[0]),
-                          GTK_RELIEF_NONE);
-    g_object_set_data(G_OBJECT(GTK_ROT_KNOB(widget)->buttons[0]),
-                      "delta", GINT_TO_POINTER(10000));
-    gtk_table_attach(GTK_TABLE(table), GTK_ROT_KNOB(widget)->buttons[0],
-                     1, 2, 0, 1, GTK_SHRINK, GTK_SHRINK, 0, 0);
-    g_signal_connect(GTK_ROT_KNOB(widget)->buttons[0], "clicked",
-                     G_CALLBACK(button_clicked_cb), widget);
-
+    GTK_ROT_KNOB(widget)->buttons[0] = gtk_button_new ();
+    gtk_container_add (GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[0]),
+                       gtk_arrow_new (GTK_ARROW_UP, GTK_SHADOW_NONE));
+    gtk_button_set_relief (GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[0]),
+                           GTK_RELIEF_NONE);
+    g_object_set_data (G_OBJECT (GTK_ROT_KNOB(widget)->buttons[0]),
+                       "delta", GINT_TO_POINTER(10000));
+    gtk_table_attach (GTK_TABLE (table), GTK_ROT_KNOB(widget)->buttons[0],
+                      1, 2, 0, 1, GTK_SHRINK, GTK_SHRINK, 0, 0);
+    g_signal_connect (GTK_ROT_KNOB(widget)->buttons[0], "clicked",
+                      G_CALLBACK (button_clicked_cb), widget);
+    
     /* +10 deg */
-    GTK_ROT_KNOB(widget)->buttons[1] = gtk_button_new();
-    gtk_container_add(GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[1]),
-                      gtk_arrow_new(GTK_ARROW_UP, GTK_SHADOW_NONE));
-    gtk_button_set_relief(GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[1]),
-                          GTK_RELIEF_NONE);
-    g_object_set_data(G_OBJECT(GTK_ROT_KNOB(widget)->buttons[1]),
-                      "delta", GINT_TO_POINTER(1000));
-    gtk_table_attach(GTK_TABLE(table), GTK_ROT_KNOB(widget)->buttons[1],
-                     2, 3, 0, 1, GTK_SHRINK, GTK_SHRINK, 0, 0);
-    g_signal_connect(GTK_ROT_KNOB(widget)->buttons[1], "clicked",
-                     G_CALLBACK(button_clicked_cb), widget);
-
+    GTK_ROT_KNOB(widget)->buttons[1] = gtk_button_new ();
+    gtk_container_add (GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[1]),
+                       gtk_arrow_new (GTK_ARROW_UP, GTK_SHADOW_NONE));
+    gtk_button_set_relief (GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[1]),
+                           GTK_RELIEF_NONE);
+    g_object_set_data (G_OBJECT (GTK_ROT_KNOB(widget)->buttons[1]),
+                       "delta", GINT_TO_POINTER(1000));
+    gtk_table_attach (GTK_TABLE (table), GTK_ROT_KNOB(widget)->buttons[1],
+                      2, 3, 0, 1, GTK_SHRINK, GTK_SHRINK, 0, 0);
+    g_signal_connect (GTK_ROT_KNOB(widget)->buttons[1], "clicked",
+                      G_CALLBACK (button_clicked_cb), widget);
+    
     /* +1 deg */
-    GTK_ROT_KNOB(widget)->buttons[2] = gtk_button_new();
-    gtk_container_add(GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[2]),
-                      gtk_arrow_new(GTK_ARROW_UP, GTK_SHADOW_NONE));
-    gtk_button_set_relief(GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[2]),
-                          GTK_RELIEF_NONE);
-    g_object_set_data(G_OBJECT(GTK_ROT_KNOB(widget)->buttons[2]),
-                      "delta", GINT_TO_POINTER(100));
-    gtk_table_attach(GTK_TABLE(table), GTK_ROT_KNOB(widget)->buttons[2],
+    GTK_ROT_KNOB(widget)->buttons[2] = gtk_button_new ();
+    gtk_container_add (GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[2]),
+                       gtk_arrow_new (GTK_ARROW_UP, GTK_SHADOW_NONE));
+    gtk_button_set_relief (GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[2]),
+                           GTK_RELIEF_NONE);
+    g_object_set_data (G_OBJECT (GTK_ROT_KNOB(widget)->buttons[2]),
+                       "delta", GINT_TO_POINTER(100));
+    gtk_table_attach (GTK_TABLE (table), GTK_ROT_KNOB(widget)->buttons[2],
                      3, 4, 0, 1, GTK_SHRINK, GTK_SHRINK, 0, 0);
-    g_signal_connect(GTK_ROT_KNOB(widget)->buttons[2], "clicked",
-                     G_CALLBACK(button_clicked_cb), widget);
-
+    g_signal_connect (GTK_ROT_KNOB(widget)->buttons[2], "clicked",
+                      G_CALLBACK (button_clicked_cb), widget);
+    
     /* +0.1 deg */
-    GTK_ROT_KNOB(widget)->buttons[3] = gtk_button_new();
-    gtk_container_add(GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[3]),
-                      gtk_arrow_new(GTK_ARROW_UP, GTK_SHADOW_NONE));
-    gtk_button_set_relief(GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[3]),
-                          GTK_RELIEF_NONE);
-    g_object_set_data(G_OBJECT(GTK_ROT_KNOB(widget)->buttons[3]),
-                      "delta", GINT_TO_POINTER(10));
-    gtk_table_attach(GTK_TABLE(table), GTK_ROT_KNOB(widget)->buttons[3],
-                     5, 6, 0, 1, GTK_SHRINK, GTK_SHRINK, 0, 0);
-    g_signal_connect(GTK_ROT_KNOB(widget)->buttons[3], "clicked",
-                     G_CALLBACK(button_clicked_cb), widget);
-
+    GTK_ROT_KNOB(widget)->buttons[3] = gtk_button_new ();
+    gtk_container_add (GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[3]),
+                       gtk_arrow_new (GTK_ARROW_UP, GTK_SHADOW_NONE));
+    gtk_button_set_relief (GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[3]),
+                           GTK_RELIEF_NONE);
+    g_object_set_data (G_OBJECT (GTK_ROT_KNOB(widget)->buttons[3]),
+                       "delta", GINT_TO_POINTER(10));
+    gtk_table_attach (GTK_TABLE (table), GTK_ROT_KNOB(widget)->buttons[3],
+                      5, 6, 0, 1, GTK_SHRINK, GTK_SHRINK, 0, 0);
+    g_signal_connect (GTK_ROT_KNOB(widget)->buttons[3], "clicked",
+                      G_CALLBACK (button_clicked_cb), widget);
+    
     /* +0.01 deg */
-    GTK_ROT_KNOB(widget)->buttons[4] = gtk_button_new();
-    gtk_container_add(GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[4]),
-                      gtk_arrow_new(GTK_ARROW_UP, GTK_SHADOW_NONE));
-    gtk_button_set_relief(GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[4]),
-                          GTK_RELIEF_NONE);
-    g_object_set_data(G_OBJECT(GTK_ROT_KNOB(widget)->buttons[4]),
-                      "delta", GINT_TO_POINTER(1));
-    gtk_table_attach(GTK_TABLE(table), GTK_ROT_KNOB(widget)->buttons[4],
-                     6, 7, 0, 1, GTK_SHRINK, GTK_SHRINK, 0, 0);
-    g_signal_connect(GTK_ROT_KNOB(widget)->buttons[4], "clicked",
-                     G_CALLBACK(button_clicked_cb), widget);
-
+    GTK_ROT_KNOB(widget)->buttons[4] = gtk_button_new ();
+    gtk_container_add (GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[4]),
+                       gtk_arrow_new (GTK_ARROW_UP, GTK_SHADOW_NONE));
+    gtk_button_set_relief (GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[4]),
+                           GTK_RELIEF_NONE);
+    g_object_set_data (G_OBJECT (GTK_ROT_KNOB(widget)->buttons[4]),
+                       "delta", GINT_TO_POINTER(1));
+    gtk_table_attach (GTK_TABLE (table), GTK_ROT_KNOB(widget)->buttons[4],
+                      6, 7, 0, 1, GTK_SHRINK, GTK_SHRINK, 0, 0);
+    g_signal_connect (GTK_ROT_KNOB(widget)->buttons[4], "clicked",
+                      G_CALLBACK (button_clicked_cb), widget);
+    
     /* -100 deg */
-    GTK_ROT_KNOB(widget)->buttons[5] = gtk_button_new();
-    gtk_container_add(GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[5]),
-                      gtk_arrow_new(GTK_ARROW_DOWN, GTK_SHADOW_NONE));
-    gtk_button_set_relief(GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[5]),
-                          GTK_RELIEF_NONE);
-    g_object_set_data(G_OBJECT(GTK_ROT_KNOB(widget)->buttons[5]),
-                      "delta", GINT_TO_POINTER(-10000));
-    gtk_table_attach(GTK_TABLE(table), GTK_ROT_KNOB(widget)->buttons[5],
-                     1, 2, 2, 3, GTK_SHRINK, GTK_SHRINK, 0, 0);
-    g_signal_connect(GTK_ROT_KNOB(widget)->buttons[5], "clicked",
-                     G_CALLBACK(button_clicked_cb), widget);
-
+    GTK_ROT_KNOB(widget)->buttons[5] = gtk_button_new ();
+    gtk_container_add (GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[5]),
+                       gtk_arrow_new (GTK_ARROW_DOWN, GTK_SHADOW_NONE));
+    gtk_button_set_relief (GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[5]),
+                           GTK_RELIEF_NONE);
+    g_object_set_data (G_OBJECT (GTK_ROT_KNOB(widget)->buttons[5]),
+                       "delta", GINT_TO_POINTER(-10000));
+    gtk_table_attach (GTK_TABLE (table), GTK_ROT_KNOB(widget)->buttons[5],
+                      1, 2, 2, 3, GTK_SHRINK, GTK_SHRINK, 0, 0);
+    g_signal_connect (GTK_ROT_KNOB(widget)->buttons[5], "clicked",
+                      G_CALLBACK (button_clicked_cb), widget);
+    
     /* -10 deg */
-    GTK_ROT_KNOB(widget)->buttons[6] = gtk_button_new();
-    gtk_container_add(GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[6]),
-                      gtk_arrow_new(GTK_ARROW_DOWN, GTK_SHADOW_NONE));
-    gtk_button_set_relief(GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[6]),
-                          GTK_RELIEF_NONE);
-    g_object_set_data(G_OBJECT(GTK_ROT_KNOB(widget)->buttons[6]),
-                      "delta", GINT_TO_POINTER(-1000));
-    gtk_table_attach(GTK_TABLE(table), GTK_ROT_KNOB(widget)->buttons[6],
-                     2, 3, 2, 3, GTK_SHRINK, GTK_SHRINK, 0, 0);
-    g_signal_connect(GTK_ROT_KNOB(widget)->buttons[6], "clicked",
-                     G_CALLBACK(button_clicked_cb), widget);
-
+    GTK_ROT_KNOB(widget)->buttons[6] = gtk_button_new ();
+    gtk_container_add (GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[6]),
+                       gtk_arrow_new (GTK_ARROW_DOWN, GTK_SHADOW_NONE));
+    gtk_button_set_relief (GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[6]),
+                           GTK_RELIEF_NONE);
+    g_object_set_data (G_OBJECT (GTK_ROT_KNOB(widget)->buttons[6]),
+                       "delta", GINT_TO_POINTER(-1000));
+    gtk_table_attach (GTK_TABLE (table), GTK_ROT_KNOB(widget)->buttons[6],
+                      2, 3, 2, 3, GTK_SHRINK, GTK_SHRINK, 0, 0);
+    g_signal_connect (GTK_ROT_KNOB(widget)->buttons[6], "clicked",
+                      G_CALLBACK (button_clicked_cb), widget);
+    
     /* -1 deg */
-    GTK_ROT_KNOB(widget)->buttons[7] = gtk_button_new();
-    gtk_container_add(GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[7]),
-                      gtk_arrow_new(GTK_ARROW_DOWN, GTK_SHADOW_NONE));
-    gtk_button_set_relief(GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[7]),
-                          GTK_RELIEF_NONE);
-    g_object_set_data(G_OBJECT(GTK_ROT_KNOB(widget)->buttons[7]),
-                      "delta", GINT_TO_POINTER(-100));
-    gtk_table_attach(GTK_TABLE(table), GTK_ROT_KNOB(widget)->buttons[7],
-                     3, 4, 2, 3, GTK_SHRINK, GTK_SHRINK, 0, 0);
-    g_signal_connect(GTK_ROT_KNOB(widget)->buttons[7], "clicked",
-                     G_CALLBACK(button_clicked_cb), widget);
-
+    GTK_ROT_KNOB(widget)->buttons[7] = gtk_button_new ();
+    gtk_container_add (GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[7]),
+                       gtk_arrow_new (GTK_ARROW_DOWN, GTK_SHADOW_NONE));
+    gtk_button_set_relief (GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[7]),
+                           GTK_RELIEF_NONE);
+    g_object_set_data (G_OBJECT (GTK_ROT_KNOB(widget)->buttons[7]),
+                       "delta", GINT_TO_POINTER(-100));
+    gtk_table_attach (GTK_TABLE (table), GTK_ROT_KNOB(widget)->buttons[7],
+                      3, 4, 2, 3, GTK_SHRINK, GTK_SHRINK, 0, 0);
+    g_signal_connect (GTK_ROT_KNOB(widget)->buttons[7], "clicked",
+                      G_CALLBACK (button_clicked_cb), widget);
+    
     /* -0.1 deg */
-    GTK_ROT_KNOB(widget)->buttons[8] = gtk_button_new();
-    gtk_container_add(GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[8]),
-                      gtk_arrow_new(GTK_ARROW_DOWN, GTK_SHADOW_NONE));
-    gtk_button_set_relief(GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[8]),
-                          GTK_RELIEF_NONE);
-    g_object_set_data(G_OBJECT(GTK_ROT_KNOB(widget)->buttons[8]),
-                      "delta", GINT_TO_POINTER(-10));
-    gtk_table_attach(GTK_TABLE(table), GTK_ROT_KNOB(widget)->buttons[8],
-                     5, 6, 2, 3, GTK_SHRINK, GTK_SHRINK, 0, 0);
-    g_signal_connect(GTK_ROT_KNOB(widget)->buttons[8], "clicked",
-                     G_CALLBACK(button_clicked_cb), widget);
-
+    GTK_ROT_KNOB(widget)->buttons[8] = gtk_button_new ();
+    gtk_container_add (GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[8]),
+                       gtk_arrow_new (GTK_ARROW_DOWN, GTK_SHADOW_NONE));
+    gtk_button_set_relief (GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[8]),
+                           GTK_RELIEF_NONE);
+    g_object_set_data (G_OBJECT (GTK_ROT_KNOB(widget)->buttons[8]),
+                       "delta", GINT_TO_POINTER(-10));
+    gtk_table_attach (GTK_TABLE (table), GTK_ROT_KNOB(widget)->buttons[8],
+                      5, 6, 2, 3, GTK_SHRINK, GTK_SHRINK, 0, 0);
+    g_signal_connect (GTK_ROT_KNOB(widget)->buttons[8], "clicked",
+                      G_CALLBACK (button_clicked_cb), widget);
+    
     /* -0.01 deg */
-    GTK_ROT_KNOB(widget)->buttons[9] = gtk_button_new();
-    gtk_container_add(GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[9]),
-                      gtk_arrow_new(GTK_ARROW_DOWN, GTK_SHADOW_NONE));
-    gtk_button_set_relief(GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[9]),
-                          GTK_RELIEF_NONE);
-    g_object_set_data(G_OBJECT(GTK_ROT_KNOB(widget)->buttons[9]),
-                      "delta", GINT_TO_POINTER(-1));
-    gtk_table_attach(GTK_TABLE(table), GTK_ROT_KNOB(widget)->buttons[9],
-                     6, 7, 2, 3, GTK_SHRINK, GTK_SHRINK, 0, 0);
-    g_signal_connect(GTK_ROT_KNOB(widget)->buttons[9], "clicked",
-                     G_CALLBACK(button_clicked_cb), widget);
+    GTK_ROT_KNOB(widget)->buttons[9] = gtk_button_new ();
+    gtk_container_add (GTK_CONTAINER(GTK_ROT_KNOB(widget)->buttons[9]),
+                       gtk_arrow_new (GTK_ARROW_DOWN, GTK_SHADOW_NONE));
+    gtk_button_set_relief (GTK_BUTTON(GTK_ROT_KNOB(widget)->buttons[9]),
+                           GTK_RELIEF_NONE);
+    g_object_set_data (G_OBJECT (GTK_ROT_KNOB(widget)->buttons[9]),
+                       "delta", GINT_TO_POINTER(-1));
+    gtk_table_attach (GTK_TABLE (table), GTK_ROT_KNOB(widget)->buttons[9],
+                      6, 7, 2, 3, GTK_SHRINK, GTK_SHRINK, 0, 0);
+    g_signal_connect (GTK_ROT_KNOB(widget)->buttons[9], "clicked",
+                      G_CALLBACK (button_clicked_cb), widget);
 
     /* create labels */
-    for (i = 0; i < 7; i++)
-    {
+    for (i = 0; i < 7; i++) {
         /* labels showing the digits */
-        GTK_ROT_KNOB(widget)->digits[i] = gtk_label_new(NULL);
+        GTK_ROT_KNOB(widget)->digits[i] = gtk_label_new (NULL);
         gtk_widget_set_tooltip_text(GTK_ROT_KNOB(widget)->digits[i],
-                                    _
-                                    ("Use mouse buttons and wheel to change value"));
+                                    _("Use mouse buttons and wheel to change value"));
 
         /* Event boxes for catching mouse evetns */
-        GTK_ROT_KNOB(widget)->evtbox[i] = gtk_event_box_new();
-        g_object_set_data(G_OBJECT(GTK_ROT_KNOB(widget)->evtbox[i]), "index",
-                          GUINT_TO_POINTER(i));
-        gtk_container_add(GTK_CONTAINER(GTK_ROT_KNOB(widget)->evtbox[i]),
-                          GTK_ROT_KNOB(widget)->digits[i]);
-        gtk_table_attach(GTK_TABLE(table), GTK_ROT_KNOB(widget)->evtbox[i], i,
-                         i + 1, 1, 2, GTK_SHRINK, GTK_SHRINK, 0, 0);
-
-        g_signal_connect(GTK_ROT_KNOB(widget)->evtbox[i], "button_press_event",
+        GTK_ROT_KNOB(widget)->evtbox[i] = gtk_event_box_new ();
+        g_object_set_data(G_OBJECT(GTK_ROT_KNOB(widget)->evtbox[i]), "index", GUINT_TO_POINTER(i));
+        gtk_container_add(GTK_CONTAINER(GTK_ROT_KNOB(widget)->evtbox[i]), GTK_ROT_KNOB(widget)->digits[i]);
+        gtk_table_attach (GTK_TABLE (table), GTK_ROT_KNOB(widget)->evtbox[i],
+                          i, i+1, 1, 2, GTK_SHRINK, GTK_SHRINK, 0, 0);
+                          
+        g_signal_connect (GTK_ROT_KNOB(widget)->evtbox[i], "button_press_event",
                          (GCallback) on_button_press, widget);
-        g_signal_connect(GTK_ROT_KNOB(widget)->evtbox[i], "scroll_event",
+        g_signal_connect (GTK_ROT_KNOB(widget)->evtbox[i], "scroll_event",
                          (GCallback) on_button_scroll, widget);
 
     }
-
+    
     /* degree sign */
     label = gtk_label_new (NULL);
     gtk_label_set_markup (GTK_LABEL (label), "<span size='xx-large'>\302\260</span>");
@@ -328,7 +326,8 @@ GtkWidget      *gtk_rot_knob_new(gdouble min, gdouble max, gdouble val)
  * \param[in] val The new value.
  * 
  */
-void gtk_rot_knob_set_value(GtkRotKnob * knob, gdouble val)
+void
+gtk_rot_knob_set_value (GtkRotKnob *knob, gdouble val)
 {
     /* set the new value */
     if (val <= knob->min)
@@ -337,7 +336,7 @@ void gtk_rot_knob_set_value(GtkRotKnob * knob, gdouble val)
         knob->value = knob->max;
     else
         knob->value = val;
-
+    
     /* update the display */
     g_idle_add((GSourceFunc) gtk_rot_knob_update, knob);
 }
@@ -350,7 +349,8 @@ void gtk_rot_knob_set_value(GtkRotKnob * knob, gdouble val)
  * Hint: For reading the value you can also access knob->value.
  * 
  */
-gdouble gtk_rot_knob_get_value(GtkRotKnob * knob)
+gdouble
+gtk_rot_knob_get_value (GtkRotKnob *knob)
 {
     return knob->value;
 }
@@ -360,7 +360,8 @@ gdouble gtk_rot_knob_get_value(GtkRotKnob * knob)
  * \param[in] knob The rotor control widget.
  * \return The upper limit of the control widget.
  */
-gdouble gtk_rot_knob_get_max(GtkRotKnob * knob)
+gdouble
+gtk_rot_knob_get_max   (GtkRotKnob *knob)
 {
     return knob->max;
 }
@@ -370,7 +371,8 @@ gdouble gtk_rot_knob_get_max(GtkRotKnob * knob)
  * \param[in] knob The rotor control widget.
  * \return The lower limit of the control widget.
  */
-gdouble gtk_rot_knob_get_min(GtkRotKnob * knob)
+gdouble
+gtk_rot_knob_get_min   (GtkRotKnob *knob)
 {
     return knob->min;
 }
@@ -380,16 +382,15 @@ gdouble gtk_rot_knob_get_min(GtkRotKnob * knob)
  * \param[in] knob The rotor control widget.
  * \param[in] min The new lower limit of the control widget.
  */
-void gtk_rot_knob_set_min(GtkRotKnob * knob, gdouble min)
+void
+gtk_rot_knob_set_min   (GtkRotKnob *knob, gdouble min)
 {
     /* just som sanity check we have only 3 digits */
-    if (min < 1000)
-    {
+    if (min < 1000) {
         knob->min = min;
-
+        
         /* ensure that current value is within range */
-        if (knob->value < knob->min)
-        {
+        if (knob->value < knob->min) {
             knob->value = knob->min;
             g_idle_add((GSourceFunc) gtk_rot_knob_update, knob);
         }
@@ -400,16 +401,15 @@ void gtk_rot_knob_set_min(GtkRotKnob * knob, gdouble min)
  * \param[in] knob The rotor control widget.
  * \param[in] min The new upper limit of the control widget.
  */
-void gtk_rot_knob_set_max(GtkRotKnob * knob, gdouble max)
+void
+gtk_rot_knob_set_max (GtkRotKnob *knob, gdouble max)
 {
     /* just som sanity check we have only 3 digits */
-    if (max < 1000)
-    {
+    if (max < 1000) {
         knob->max = max;
-
+        
         /* ensure that current value is within range */
-        if (knob->value > knob->max)
-        {
+        if (knob->value > knob->max) {
             knob->value = knob->max;
             g_idle_add((GSourceFunc) gtk_rot_knob_update, knob);
         }
@@ -422,10 +422,11 @@ void gtk_rot_knob_set_max(GtkRotKnob * knob, gdouble max)
  * \param[in] min The new lower limit of the control widget.
  * \param[in] max The new upper limit of the control widget.
  */
-void gtk_rot_knob_set_range(GtkRotKnob * knob, gdouble min, gdouble max)
+void
+gtk_rot_knob_set_range (GtkRotKnob *knob, gdouble min, gdouble max)
 {
-    gtk_rot_knob_set_min(knob, min);
-    gtk_rot_knob_set_max(knob, max);
+    gtk_rot_knob_set_min (knob, min);
+    gtk_rot_knob_set_max (knob, max);
 }
 
 
@@ -446,15 +447,14 @@ static void
     g_ascii_formatd (b, 8, "%6.2f", fabs(knob->value)); 
     
     /* set label markups */
-    for (i = 0; i < 6; i++)
-    {
-        buff = g_strdup_printf(FMTSTR, b[i]);
-        gtk_label_set_markup(GTK_LABEL(knob->digits[i + 1]), buff);
-        g_free(buff);
+    for (i = 0; i < 6; i++) {
+        buff = g_strdup_printf (FMTSTR, b[i]);
+        gtk_label_set_markup (GTK_LABEL(knob->digits[i+1]), buff);
+        g_free (buff);
     }
-
+    
     if (knob->value < 0)
-        buff = g_strdup_printf(FMTSTR, '-');
+        buff = g_strdup_printf (FMTSTR, '-');
     else
         buff = g_strdup_printf (FMTSTR, ' ');
     
@@ -473,30 +473,24 @@ static void
  * \param data Pointer to the GtkRotKnob widget.
  * 
  */
-static void button_clicked_cb(GtkWidget * button, gpointer data)
+static void
+button_clicked_cb (GtkWidget *button, gpointer data)
 {
-    GtkRotKnob     *knob = GTK_ROT_KNOB(data);
-    gdouble         delta =
-        GPOINTER_TO_INT(g_object_get_data(G_OBJECT(button), "delta")) / 100.0;
-
-    if ((delta > 0.0) && ((knob->value + delta) <= knob->max + .005))
-    {
+    GtkRotKnob *knob = GTK_ROT_KNOB (data);
+    gdouble delta = GPOINTER_TO_INT(g_object_get_data (G_OBJECT (button), "delta")) / 100.0;
+    
+    if ((delta > 0.0) && ((knob->value + delta) <= knob->max+.005)) {
         knob->value += delta;
-        if (knob->value > knob->max)
-        {
-            knob->value = knob->max;
-        }
+          if (knob->value>knob->max){
+               knob->value=knob->max;
+          }
     }
-    else if ((delta < 0.0) && ((knob->value + delta) >= knob->min - .005))
-    {
+    else if ((delta < 0.0) && ((knob->value + delta) >= knob->min-.005)) {
         knob->value += delta;
-        if (knob->value < knob->min)
-        {
-            knob->value = knob->min;
-        }
-    }
-    else
-    {
+          if (knob->value<knob->min){
+               knob->value=knob->min;
+          }
+    } else {
         //g_print("Val: %.2f %.2f %.10f\n",knob->value,delta,knob->value+delta);
      }
     
@@ -526,30 +520,27 @@ static void button_clicked_cb(GtkWidget * button, gpointer data)
  * can use the INDEX_TO_DELTA[] array. The index to this table is attached to the evtbox.
  * Whether the delta is positive or negative depends on which mouse button triggered the event.
  */
-static gboolean on_button_press(GtkWidget * evtbox,
-                                GdkEventButton * event, gpointer data)
+static gboolean on_button_press (GtkWidget *evtbox,
+                                 GdkEventButton *event,
+                                 gpointer data)
 {
-    GtkRotKnob     *knob = GTK_ROT_KNOB(data);
-    guint           idx =
-        GPOINTER_TO_UINT(g_object_get_data(G_OBJECT(evtbox), "index"));
-    gdouble         delta = INDEX_TO_DELTA[idx];
-    gdouble         value;
+    GtkRotKnob *knob = GTK_ROT_KNOB(data);
+    guint idx = GPOINTER_TO_UINT(g_object_get_data (G_OBJECT (evtbox), "index"));
+    gdouble delta = INDEX_TO_DELTA[idx];
+    gdouble value;
 
-    if (delta < 0.01)
-    {
+    if (delta < 0.01) {
         /* no change, user clicked on sign or decimal separator */
         return TRUE;
     }
-
-    if (event->type != GDK_BUTTON_PRESS)
-    {
+    
+    if (event->type != GDK_BUTTON_PRESS) {
         /* wrong event (not possible?) */
         return TRUE;
     }
 
 
-    switch (event->button)
-    {
+    switch (event->button) {
 
         /* left button */
     case 1:
@@ -592,30 +583,27 @@ static gboolean on_button_press(GtkWidget * evtbox,
  * can use the INDEX_TO_DELTA[] array. The index is attached to the evtbox.
  * Whether the delta is positive or negative depends on the scroll direction.
  */
-static gboolean on_button_scroll(GtkWidget * evtbox,
-                                 GdkEventScroll * event, gpointer data)
+static gboolean on_button_scroll (GtkWidget *evtbox,
+                                  GdkEventScroll *event,
+                                  gpointer data)
 {
-    GtkRotKnob     *knob = GTK_ROT_KNOB(data);
-    guint           idx =
-        GPOINTER_TO_UINT(g_object_get_data(G_OBJECT(evtbox), "index"));
-    gdouble         delta = INDEX_TO_DELTA[idx];
-    gdouble         value;
+    GtkRotKnob *knob = GTK_ROT_KNOB(data);
+    guint idx = GPOINTER_TO_UINT(g_object_get_data (G_OBJECT (evtbox), "index"));
+    gdouble delta = INDEX_TO_DELTA[idx];
+    gdouble value;
 
-    if (delta < 0.01)
-    {
+    if (delta < 0.01) {
         /* no change, user clicked on sign or decimal separator */
         return TRUE;
     }
-
-    if (event->type != GDK_SCROLL)
-    {
+    
+    if (event->type != GDK_SCROLL) {
         /* wrong event (not possible?) */
         return TRUE;
     }
 
 
-    switch (event->direction)
-    {
+    switch (event->direction) {
 
         /* decrease value by delta */
     case GDK_SCROLL_DOWN:
@@ -638,3 +626,4 @@ static gboolean on_button_scroll(GtkWidget * evtbox,
 
     return TRUE;
 }
+

--- a/src/gtk-rot-knob.h
+++ b/src/gtk-rot-knob.h
@@ -34,8 +34,8 @@
 
 
 #ifdef __cplusplus
-extern          "C" {
-#endif                          /* __cplusplus */
+extern "C" {
+#endif /* __cplusplus */
 
 
 
@@ -52,45 +52,47 @@ extern          "C" {
 #define IS_GTK_ROT_KNOB(obj)       G_TYPE_CHECK_INSTANCE_TYPE (obj, gtk_rot_knob_get_type ())
 
 
-    typedef struct _gtk_rot_knob GtkRotKnob;
-    typedef struct _GtkRotKnobClass GtkRotKnobClass;
+typedef struct _gtk_rot_knob      GtkRotKnob;
+typedef struct _GtkRotKnobClass   GtkRotKnobClass;
 
 
 
-    struct _gtk_rot_knob {
-        GtkVBox         vbox;
+struct _gtk_rot_knob
+{
+    GtkVBox vbox;
+    
+    GtkWidget *digits[7];   /*!< Labels for the digits */
+    GtkWidget *evtbox[7];   /*!< Event boxes to catch mouse events over the digits */
+    GtkWidget *buttons[10]; /*!< Buttons; 0..4 up; 5..9 down */
+     
+    gdouble min;
+    gdouble max;
+    gdouble value;
+};
 
-        GtkWidget      *digits[7];      /*!< Labels for the digits */
-        GtkWidget      *evtbox[7];      /*!< Event boxes to catch mouse events over the digits */
-        GtkWidget      *buttons[10];    /*!< Buttons; 0..4 up; 5..9 down */
-
-        gdouble         min;
-        gdouble         max;
-        gdouble         value;
-    };
-
-    struct _GtkRotKnobClass {
-        GtkVBoxClass    parent_class;
-    };
+struct _GtkRotKnobClass
+{
+     GtkVBoxClass parent_class;
+};
 
 
 
-    GType           gtk_rot_knob_get_type(void);
-    GtkWidget      *gtk_rot_knob_new(gdouble min, gdouble max, gdouble val);
-    void            gtk_rot_knob_set_value(GtkRotKnob * knob, gdouble val);
-    gdouble         gtk_rot_knob_get_value(GtkRotKnob * knob);
-    void            gtk_rot_knob_set_max(GtkRotKnob * knob, gdouble max);
-    gdouble         gtk_rot_knob_get_max(GtkRotKnob * knob);
-    gdouble         gtk_rot_knob_get_min(GtkRotKnob * knob);
-    void            gtk_rot_knob_set_min(GtkRotKnob * knob, gdouble min);
-    void            gtk_rot_knob_set_max(GtkRotKnob * knob, gdouble max);
-    void            gtk_rot_knob_set_range(GtkRotKnob * knob, gdouble min,
-                                           gdouble max);
+GType      gtk_rot_knob_get_type  (void);
+GtkWidget* gtk_rot_knob_new       (gdouble min, gdouble max, gdouble val);
+void       gtk_rot_knob_set_value (GtkRotKnob *knob, gdouble val);
+gdouble    gtk_rot_knob_get_value (GtkRotKnob *knob);
+void       gtk_rot_knob_set_max   (GtkRotKnob *knob, gdouble max);
+gdouble    gtk_rot_knob_get_max   (GtkRotKnob *knob);
+gdouble    gtk_rot_knob_get_min   (GtkRotKnob *knob);
+void       gtk_rot_knob_set_min   (GtkRotKnob *knob, gdouble min);
+void       gtk_rot_knob_set_max   (GtkRotKnob *knob, gdouble max);
+void       gtk_rot_knob_set_range (GtkRotKnob *knob, gdouble min, gdouble max);
 
 
 
 
 #ifdef __cplusplus
 }
-#endif                          /* __cplusplus */
-#endif                          /* __GTK_ROT_knob_H__ */
+#endif /* __cplusplus */
+
+#endif /* __GTK_ROT_knob_H__ */

--- a/src/main.c
+++ b/src/main.c
@@ -173,23 +173,12 @@ int main(int argc, char *argv[])
     gpredict_app_create();
     gtk_widget_show_all(app);
 
-#if 0
-    /** FIXME: store thread and destroy on exit? **/
-    g_thread_try_new(_("gpredict_gui"), gui_task, NULL,
-		     &err);
-    
-    if (err != NULL)
-      sat_log_log(SAT_LOG_LEVEL_ERROR,
-		  _("%s: Failed to create gui thread (%s)"),
-		  __func__, err->message);
-#endif
-
     //sat_debugger_run ();
 
     /* launch rigctld communication task */
     /** FIXME: store thread and destroy on exit? **/
     /** FIXME: start with timercallback to ensure config ist set? **/
-    g_thread_try_new(_("gpredict_rigtcl_task"), rigctl_run, rigctl_task_data,
+    g_thread_try_new(_("rigtcl_run"), rigctl_run, rigctl_task_data,
 		     &err);
     
     if (err != NULL)

--- a/src/main.c
+++ b/src/main.c
@@ -54,7 +54,7 @@
 #include "sat-cfg.h"
 #include "sat-debugger.h"
 #include "sat-log.h"
-#include "gtk-rig-ctrl.h"
+
 
 /** Main application widget. */
 GtkWidget      *app;
@@ -87,7 +87,6 @@ static gboolean tle_upd_note_sent = FALSE;
 
 
 /* private funtion prototypes */
-//static gpointer gui_task(gpointer data);
 static void     gpredict_app_create(void);
 static gint     gpredict_app_delete(GtkWidget *, GdkEvent *, gpointer);
 static void     gpredict_app_destroy(GtkWidget *, gpointer);
@@ -111,6 +110,7 @@ int main(int argc, char *argv[])
     GError         *err = NULL;
     GOptionContext *context;
     guint           error = 0;
+
 
 
 #ifdef ENABLE_NLS
@@ -161,31 +161,12 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    sat_log_log(SAT_LOG_LEVEL_DEBUG,
-		_("%s:%s: context: %p"),
-		__FILE__, __func__, g_thread_self());
-    
-    /* start main gui process in separate thread */
-    sat_log_log(SAT_LOG_LEVEL_DEBUG,
-		_("%s: Starting new gui thread."), __func__);
-    
     /* create application */
     gpredict_app_create();
     gtk_widget_show_all(app);
 
     //sat_debugger_run ();
 
-    /* launch rigctld communication task */
-    /** FIXME: store thread and destroy on exit? **/
-    /** FIXME: start with timercallback to ensure config ist set? **/
-    g_thread_try_new(_("rigtcl_run"), rigctl_run, rigctl_task_data,
-		     &err);
-    
-    if (err != NULL)
-      sat_log_log(SAT_LOG_LEVEL_ERROR,
-		  _("%s: Failed to create rigctl thread (%s)"),
-		  __func__, err->message);
-    
     /* launch TLE monitoring task; 10 min interval */
     tle_mon_id = g_timeout_add(600000, tle_mon_task, NULL);
 
@@ -201,7 +182,6 @@ int main(int argc, char *argv[])
     sat_cfg_save();
     sat_log_close();
     sat_cfg_close();
-
 
 #ifdef WIN32
     CloseWinSock2();
@@ -696,24 +676,3 @@ static void clean_trsp(void)
     g_free(targetdirname);
 
 }
-
-#if 0
-static gpointer gui_task(gpointer data)
-{
-  (void)data;
-
-  sat_log_log(SAT_LOG_LEVEL_DEBUG,
-		_("%s: Starting new gui thread."), __func__);
-  sat_log_log(SAT_LOG_LEVEL_DEBUG,
-	      _("%s:%s: context: %p"),
-	      __FILE__, __func__, g_thread_self());
-  
-  /* create application */
-  gpredict_app_create();
-  gtk_widget_show_all(app);
-
-  while(1);
-  return NULL;
-}
-#endif
-


### PR DESCRIPTION
Added worker threads for rig- and rot-controller widgets.
Tested with at least 2 Modules:  first one is used with a real radio (YAESU FT-847) and the second one is used with gqrx. rot-controller widget is tested with a dummy-device only.