### PR TITLE
Avoid gcc-centric code

### DIFF
--- a/src/gpredict-utils.c
+++ b/src/gpredict-utils.c
@@ -573,3 +573,26 @@ gboolean gpredict_save_key_file(GKeyFile * cfgdata, const char *filename)
 
     return err;
 }
+
+
+/**
+ * Check if \c ch is an alpha-num; in range \c "[0-9a-zA-F]".
+ * Or \c "ch == '-'" or \c "ch == '_'".
+ *
+ * @param ch the character code to check.
+ * @return TRUE if okay.
+ */
+gboolean gpredict_legal_char (int ch)
+{
+  if (g_ascii_isalnum(ch))
+     return (TRUE);
+
+  if (ch == '-')
+     return (TRUE);
+
+  if (ch == '_')
+     return (TRUE);
+
+  return (FALSE);
+}
+

--- a/src/gpredict-utils.c
+++ b/src/gpredict-utils.c
@@ -584,15 +584,8 @@ gboolean gpredict_save_key_file(GKeyFile * cfgdata, const char *filename)
  */
 gboolean gpredict_legal_char (int ch)
 {
-  if (g_ascii_isalnum(ch))
+  if (g_ascii_isalnum(ch) || ch == '-' || ch == '_')
      return (TRUE);
-
-  if (ch == '-')
-     return (TRUE);
-
-  if (ch == '_')
-     return (TRUE);
-
   return (FALSE);
 }
 

--- a/src/gpredict-utils.h
+++ b/src/gpredict-utils.h
@@ -61,4 +61,5 @@ int             gpredict_strcmp(const char *s1, const char *s2);
 char           *gpredict_strcasestr(const char *s1, const char *s2);
 gboolean        gpredict_save_key_file(GKeyFile * cfgdata,
                                        const char *filename);
+gboolean        gpredict_legal_char (int ch);
 #endif

--- a/src/gtk-sat-module-popup.c
+++ b/src/gtk-sat-module-popup.c
@@ -1197,19 +1197,11 @@ static void name_changed(GtkWidget * widget, gpointer data)
         end = entry + g_utf8_strlen(entry, -1);
         for (j = entry; j < end; ++j)
         {
-            switch (*j)
+            if (!gpredict_legal_char(*j))
             {
-            case '0' ... '9':
-            case 'a' ... 'z':
-            case 'A' ... 'Z':
-            case '-':
-            case '_':
-                break;
-            default:
                 gdk_beep();
                 pos = gtk_editable_get_position(GTK_EDITABLE(widget));
                 gtk_editable_delete_text(GTK_EDITABLE(widget), pos, pos + 1);
-                break;
             }
         }
     }

--- a/src/mod-cfg.c
+++ b/src/mod-cfg.c
@@ -229,19 +229,11 @@ static void name_changed(GtkWidget * widget, gpointer data)
         end = entry + g_utf8_strlen(entry, -1);
         for (j = entry; j < end; ++j)
         {
-            switch (*j)
+            if (!gpredict_legal_char(*j))
             {
-            case '0' ... '9':
-            case 'a' ... 'z':
-            case 'A' ... 'Z':
-            case '-':
-            case '_':
-                break;
-            default:
                 gdk_beep();
                 pos = gtk_editable_get_position(GTK_EDITABLE(widget));
                 gtk_editable_delete_text(GTK_EDITABLE(widget), pos, pos + 1);
-                break;
             }
         }
     }

--- a/src/qth-editor.c
+++ b/src/qth-editor.c
@@ -566,19 +566,11 @@ static void name_changed(GtkWidget * widget, gpointer data)
         end = entry + g_utf8_strlen(entry, -1);
         for (j = entry; j < end; ++j)
         {
-            switch (*j)
+            if (!gpredict_legal_char(*j))
             {
-            case '0' ... '9':
-            case 'a' ... 'z':
-            case 'A' ... 'Z':
-            case '-':
-            case '_':
-                break;
-            default:
                 gdk_beep();
                 pos = gtk_editable_get_position(GTK_EDITABLE(widget));
                 gtk_editable_delete_text(GTK_EDITABLE(widget), pos, pos + 1);
-                break;
             }
         }
     }

--- a/src/sat-pref-layout.c
+++ b/src/sat-pref-layout.c
@@ -15,12 +15,12 @@
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation; either version 2 of the License, or
   (at your option) any later version.
-  
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
   along with this program; if not, visit http://www.fsf.org/
 */
@@ -541,10 +541,10 @@ static void layout_code_changed(GtkWidget * widget, gpointer data)
         end = entry + g_utf8_strlen(entry, -1);
         for (j = entry; j < end; ++j)
         {
-            switch (*j)
+            int c = *j;
+
+            if (g_ascii_isdigit(c) || c == ';')
             {
-            case '0' ... '9':
-            case ';':
                 dirty = TRUE;
                 /* ensure combo box is set to custom */
                 if (gtk_combo_box_get_active(GTK_COMBO_BOX(selector)) !=
@@ -553,12 +553,12 @@ static void layout_code_changed(GtkWidget * widget, gpointer data)
                     gtk_combo_box_set_active(GTK_COMBO_BOX(selector),
                                              PREDEF_NUM - 1);
                 }
-                break;
-            default:
+            }
+            else
+            {
                 gdk_beep();
                 pos = gtk_editable_get_position(GTK_EDITABLE(widget));
                 gtk_editable_delete_text(GTK_EDITABLE(widget), pos, pos + 1);
-                break;
             }
         }
     }

--- a/src/sat-pref-qth-editor.c
+++ b/src/sat-pref-qth-editor.c
@@ -637,19 +637,11 @@ static void name_changed(GtkWidget * widget, gpointer data)
         end = entry + g_utf8_strlen(entry, -1);
         for (j = entry; j < end; ++j)
         {
-            switch (*j)
+            if (!gpredict_legal_char(*j))
             {
-            case '0' ... '9':
-            case 'a' ... 'z':
-            case 'A' ... 'Z':
-            case '-':
-            case '_':
-                break;
-            default:
                 gdk_beep();
                 pos = gtk_editable_get_position(GTK_EDITABLE(widget));
                 gtk_editable_delete_text(GTK_EDITABLE(widget), pos, pos + 1);
-                break;
             }
         }
     }

--- a/src/sat-pref-rig-editor.c
+++ b/src/sat-pref-rig-editor.c
@@ -520,19 +520,11 @@ static void name_changed(GtkWidget * widget, gpointer data)
         end = entry + g_utf8_strlen(entry, -1);
         for (j = entry; j < end; ++j)
         {
-            switch (*j)
+            if (!gpredict_legal_char(*j))
             {
-            case '0' ... '9':
-            case 'a' ... 'z':
-            case 'A' ... 'Z':
-            case '-':
-            case '_':
-                break;
-            default:
                 gdk_beep();
                 pos = gtk_editable_get_position(GTK_EDITABLE(widget));
                 gtk_editable_delete_text(GTK_EDITABLE(widget), pos, pos + 1);
-                break;
             }
         }
     }

--- a/src/sat-pref-rot-editor.c
+++ b/src/sat-pref-rot-editor.c
@@ -378,19 +378,11 @@ static void name_changed(GtkWidget * widget, gpointer data)
         end = entry + g_utf8_strlen(entry, -1);
         for (j = entry; j < end; ++j)
         {
-            switch (*j)
+            if (!gpredict_legal_char(*j))
             {
-            case '0' ... '9':
-            case 'a' ... 'z':
-            case 'A' ... 'Z':
-            case '-':
-            case '_':
-                break;
-            default:
                 gdk_beep();
                 pos = gtk_editable_get_position(GTK_EDITABLE(widget));
                 gtk_editable_delete_text(GTK_EDITABLE(widget), pos, pos + 1);
-                break;
             }
         }
     }

--- a/src/save-pass.c
+++ b/src/save-pass.c
@@ -35,6 +35,7 @@
 #include "sat-cfg.h"
 #include "sat-log.h"
 #include "sat-pass-dialogs.h"
+#include "gpredict-utils.h"
 #include "save-pass.h"
 #include "sgpsdp/sgp4sdp4.h"
 
@@ -377,19 +378,11 @@ static void file_changed(GtkWidget * widget, gpointer data)
         end = entry + g_utf8_strlen(entry, -1);
         for (j = entry; j < end; ++j)
         {
-            switch (*j)
+            if (!gpredict_legal_char(*j))
             {
-            case '0' ... '9':
-            case 'a' ... 'z':
-            case 'A' ... 'Z':
-            case '-':
-            case '_':
-                break;
-            default:
                 gdk_beep();
                 pos = gtk_editable_get_position(GTK_EDITABLE(widget));
                 gtk_editable_delete_text(GTK_EDITABLE(widget), pos, pos + 1);
-                break;
             }
         }
     }


### PR DESCRIPTION
Added an `gpredict_legal_char()` function to `gpredict-utils.c` to avoid using gcc-centric code like:
```
            case '0' ... '9':
            case 'a' ... 'z':
            case 'A' ... 'Z':
```
all over the place. This was in-fact the main hurdle to be able to compile using MSVC.
Glib documents the `g_ascii_isalnum()` here:
  https://developer.gnome.org/glib/stable/glib-String-Utility-Functions.html#g-ascii-isalnum
