### PR TITLE
Remove resource leak in gtk-rot-ctrl.c

### DIFF
--- a/src/gtk-rot-ctrl.c
+++ b/src/gtk-rot-ctrl.c
@@ -138,8 +138,8 @@ static gint rotctld_socket_open(const gchar * host, gint port)
                     _("Connection to rotctld server at %s:%d failed: %s"),
                     host, port);
 
-	sock = -1;
-        return sock;
+	close(sock);
+        return -1;
     }
 
     sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s: Connection opened to %s:%d"),

--- a/src/gtk-rot-ctrl.c
+++ b/src/gtk-rot-ctrl.c
@@ -118,7 +118,7 @@ static gint rotctld_socket_open(const gchar * host, gint port)
     {
         sat_log_log(SAT_LOG_LEVEL_ERROR,
                     _("Failed to create rotctl socket: %s"), strerror(errno));
-        return -1;
+        return sock;
     }
 
     sat_log_log(SAT_LOG_LEVEL_DEBUG,
@@ -138,7 +138,8 @@ static gint rotctld_socket_open(const gchar * host, gint port)
                     _("Connection to rotctld server at %s:%d failed: %s"),
                     host, port);
 
-        return -1;
+	sock = -1;
+        return sock;
     }
 
     sat_log_log(SAT_LOG_LEVEL_DEBUG, _("%s: Connection opened to %s:%d"),


### PR DESCRIPTION
A socket handle pointed to by "sock" is lost when leaving the open-function without closing the handle.
