### PR TITLE
Fix automake warning.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_INIT([gpredict],
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR(src/main.c)
 AM_CONFIG_HEADER(build-config.h)
-AM_INIT_AUTOMAKE([dist-bzip2 no-dist-gzip 1.6])
+AM_INIT_AUTOMAKE([subdir-objects dist-bzip2 no-dist-gzip 1.6])
 
 # ensure Makefiles are updated when Makefile.am is modified
 AM_MAINTAINER_MODE([enable])


### PR DESCRIPTION
Hello

This is a trivial fix for the automake warnings.

```
src/Makefile.am:26: warning: source file 'nxjson/nxjson.c' is in a subdirectory,
src/Makefile.am:26: but option 'subdir-objects' is disabled
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
src/Makefile.am:26: warning: source file 'sgpsdp/sgp4sdp4.c' is in a subdirectory,
src/Makefile.am:26: but option 'subdir-objects' is disabled
src/Makefile.am:26: warning: source file 'sgpsdp/sgp_in.c' is in a subdirectory,
src/Makefile.am:26: but option 'subdir-objects' is disabled
src/Makefile.am:26: warning: source file 'sgpsdp/sgp_math.c' is in a subdirectory,
src/Makefile.am:26: but option 'subdir-objects' is disabled
src/Makefile.am:26: warning: source file 'sgpsdp/sgp_obs.c' is in a subdirectory,
src/Makefile.am:26: but option 'subdir-objects' is disabled
src/Makefile.am:26: warning: source file 'sgpsdp/sgp_time.c' is in a subdirectory,
src/Makefile.am:26: but option 'subdir-objects' is disabled
src/Makefile.am:26: warning: source file 'sgpsdp/solar.c' is in a subdirectory,
src/Makefile.am:26: but option 'subdir-objects' is disabled
```