### PR TITLE
Added Charlottetown, PEI to locations.dat

### DIFF
--- a/data/locations.dat
+++ b/data/locations.dat
@@ -1371,6 +1371,7 @@ Canada;Ontario;Ottawa;CYOW;45.3167;-75.6667;114
 Canada;Ontario;Toronto;CYYZ;43.6667;-79.6333;173
 Canada;Ontario;Trenton;CYTR;44.1167;-77.5333;86
 Canada;Ontario;Windsor;CYQG;42.2667;-82.9667;190
+Canada;Prince Edward Island;Charlottetown;CYYG;46.2891;-63.1191;48
 Canada;Quebec;Bagotville;CYBG;48.3333;-71;159
 Canada;Quebec;Gatineau;CYND;45.5167;-75.5667;0
 Canada;Quebec;La Grande;CYGL;53.6333;-77.7;195


### PR DESCRIPTION
Prince Edward Island was absent from the locations.dat file, so I've added an entry for the Charlottetown Airport (CYYG).

I have confirmed my changes work in gpredict and that the new location is marked correctly on the map, as can be seen in the following image:
![gpredict_new_location](https://user-images.githubusercontent.com/5630472/34642585-bb2f9b0c-f2eb-11e7-9cbf-306f3ed5dce4.png)

[You can find details about the airport here to confirm location.](https://tools.wmflabs.org/geohack/geohack.php?pagename=Charlottetown_Airport&params=46_17_21_N_063_07_09_W_region:CA-PE_type:airport)