### PR TITLE
Ensure next events are in chronological order

### DIFF
--- a/src/gtk-sat-list.c
+++ b/src/gtk-sat-list.c
@@ -732,13 +732,13 @@ static gboolean sat_list_update_sats(GtkTreeModel * model, GtkTreePath * path,
             {
                 /* next event is LOS */
                 number = sat->los;
-                alstr = g_strdup("LOS: ");
+                alstr = g_strdup(" (LOS)");
             }
             else
             {
                 /* next event is AOS */
                 number = sat->aos;
-                alstr = g_strdup("AOS: ");
+                alstr = g_strdup(" (AOS)");
             }
 
             if (number == 0.0)
@@ -751,7 +751,7 @@ static gboolean sat_list_update_sats(GtkTreeModel * model, GtkTreePath * path,
 
                 /* format the number */
                 tfstr = sat_cfg_get_str(SAT_CFG_STR_TIME_FORMAT);
-                fmtstr = g_strconcat(alstr, tfstr, NULL);
+                fmtstr = g_strconcat(tfstr, alstr, NULL);
                 g_free(tfstr);
 
                 daynum_to_str(buff, TIME_FORMAT_MAX_LENGTH, fmtstr, number);


### PR DESCRIPTION
I've been using this view for awhile now and it 'works' for me, in that I personally prefer to have the events sorted by datetime first, and type second.  I'm not sure if this is something that applies to the larger audience as a whole, but it's a trivial code change so I'm submitting it as pull request.  If, after discussion, everyone hates I'll just close the request.

Details:

- As it currently stands, the GTK list widget will sort in alphabetical order.
- When the AOS and LOS labels are prepended to the text, the event list is no longer in chronological order.

There are two potential solutions:
1) Break the 'event type' into  separate column
2) Move the event type to the end of the formatted string

The latter is much easier (this pull request implements that), but it may not jive with the 'vision' for that particular view.  The former will take some development work. 
