### PR TITLE
Operational Status as a List View Option

### DIFF
--- a/src/gtk-sat-list.c
+++ b/src/gtk-sat-list.c
@@ -73,6 +73,7 @@ const gchar    *SAT_LIST_COL_TITLE[SAT_LIST_COL_NUMBER] = {
     N_("Orbit"),
     N_("Vis"),
     N_("Decayed"),
+    N_("Status"),
     N_("BOLD")                  /* should never be seen */
 };
 
@@ -105,6 +106,7 @@ const gchar    *SAT_LIST_COL_HINT[SAT_LIST_COL_NUMBER] = {
     N_("Orbit Number"),
     N_("Visibility"),
     N_("Decayed"),
+    N_("Operational Status"),
     N_("---")
 };
 
@@ -134,6 +136,7 @@ const gfloat    SAT_LIST_COL_XALIGN[SAT_LIST_COL_NUMBER] = {
     0.0,                        // phase
     1.0,                        // orbit
     0.5,                        // visibility
+    0.0,                        // Operational Status
 };
 
 static void     gtk_sat_list_class_init(GtkSatListClass * class);
@@ -184,10 +187,19 @@ static void     two_dec_cell_data_function(GtkTreeViewColumn * col,
                                            GtkTreeIter * iter,
                                            gpointer column);
 
+
+static void     operational_status_cell_data_function(GtkTreeViewColumn * col,
+                                           GtkCellRenderer * renderer,
+                                           GtkTreeModel * model,
+                                           GtkTreeIter * iter,
+                                           gpointer column);
+
+
 static void     event_cell_data_function(GtkTreeViewColumn * col,
                                          GtkCellRenderer * renderer,
                                          GtkTreeModel * model,
                                          GtkTreeIter * iter, gpointer column);
+
 
 static gint     event_cell_compare_function(GtkTreeModel * model,
                                             GtkTreeIter * a, GtkTreeIter * b,
@@ -440,6 +452,7 @@ static GtkTreeModel *create_and_fill_model(GHashTable * sats)
                                    G_TYPE_LONG, // orbit
                                    G_TYPE_STRING,       // visibility
                                    G_TYPE_BOOLEAN,      // decay
+                                   G_TYPE_INT,       // Operational Status
                                    G_TYPE_INT   // weight/bold
         );
 
@@ -485,8 +498,9 @@ static void sat_list_add_satellites(gpointer key, gpointer value,
                        SAT_LIST_COL_DELAY, 0.0,
                        SAT_LIST_COL_MA, sat->ma,
                        SAT_LIST_COL_PHASE, sat->phase,
-                       SAT_LIST_COL_ORBIT, sat->orbit, SAT_LIST_COL_DECAY,
-                       !decayed(sat), -1);
+                       SAT_LIST_COL_ORBIT, sat->orbit, 
+                       SAT_LIST_COL_STAT_OPERATIONAL, (char *) sat->tle.status,
+                       SAT_LIST_COL_DECAY, !decayed(sat), -1);
 }
 
 /** Update satellites */
@@ -856,10 +870,71 @@ static void check_and_set_cell_renderer(GtkTreeViewColumn * column,
                                                 event_cell_data_function,
                                                 GUINT_TO_POINTER(i), NULL);
         break;
+    
+    case SAT_LIST_COL_STAT_OPERATIONAL:
+        gtk_tree_view_column_set_cell_data_func(column,
+                                                renderer,
+                                                operational_status_cell_data_function,
+                                                GUINT_TO_POINTER(i), NULL);
+        break;
+    
 
     default:
         break;
     }
+}
+
+/* Render column containing the operational status */
+static void     operational_status_cell_data_function(GtkTreeViewColumn * col,
+                                           GtkCellRenderer * renderer,
+                                           GtkTreeModel * model,
+                                           GtkTreeIter * iter,
+                                           gpointer column)
+{
+    gint            number;
+    guint           coli = GPOINTER_TO_UINT(column);
+
+    (void)col;                  /* avoid unusued parameter compiler warning */
+
+    gtk_tree_model_get(model, iter, coli, &number, -1);
+
+
+    //g_object_set(renderer, "text", "test", NULL);
+    //g_free(buff);
+
+    switch (number)
+    {
+
+    case OP_STAT_OPERATIONAL:
+        g_object_set(renderer, "text", "Operational");
+        break;
+
+    case OP_STAT_NONOP:
+        g_object_set(renderer, "text", "Non-operational");
+        break;
+
+    case OP_STAT_PARTIAL:
+        g_object_set(renderer, "text", "Partially operational");
+        break;
+
+    case OP_STAT_STDBY:
+        g_object_set(renderer, "text", "Backup/Standby");
+        break;
+
+    case OP_STAT_SPARE:
+        g_object_set(renderer, "text", "Spare");
+        break;
+
+    case OP_STAT_EXTENDED:
+        g_object_set(renderer, "text", "Extended Mission");
+        break;
+
+    default:
+        g_object_set(renderer, "text", "Unknown");
+        break;
+
+    }
+
 }
 
 /* Render column containg lat/lon

--- a/src/gtk-sat-list.c
+++ b/src/gtk-sat-list.c
@@ -898,39 +898,35 @@ static void     operational_status_cell_data_function(GtkTreeViewColumn * col,
 
     gtk_tree_model_get(model, iter, coli, &number, -1);
 
-
-    //g_object_set(renderer, "text", "test", NULL);
-    //g_free(buff);
-
     switch (number)
     {
 
     case OP_STAT_OPERATIONAL:
-        g_object_set(renderer, "text", "Operational");
+        g_object_set(renderer, "text", "Operational", NULL);
         break;
 
     case OP_STAT_NONOP:
-        g_object_set(renderer, "text", "Non-operational");
+        g_object_set(renderer, "text", "Non-operational", NULL);
         break;
 
     case OP_STAT_PARTIAL:
-        g_object_set(renderer, "text", "Partially operational");
+        g_object_set(renderer, "text", "Partially operational", NULL);
         break;
 
     case OP_STAT_STDBY:
-        g_object_set(renderer, "text", "Backup/Standby");
+        g_object_set(renderer, "text", "Backup/Standby", NULL);
         break;
 
     case OP_STAT_SPARE:
-        g_object_set(renderer, "text", "Spare");
+        g_object_set(renderer, "text", "Spare", NULL);
         break;
 
     case OP_STAT_EXTENDED:
-        g_object_set(renderer, "text", "Extended Mission");
+        g_object_set(renderer, "text", "Extended Mission", NULL);
         break;
 
     default:
-        g_object_set(renderer, "text", "Unknown");
+        g_object_set(renderer, "text", "Unknown", NULL);
         break;
 
     }

--- a/src/gtk-sat-list.h
+++ b/src/gtk-sat-list.h
@@ -103,6 +103,7 @@ typedef enum {
     SAT_LIST_COL_ORBIT,         /*!< Orbit Number. */
     SAT_LIST_COL_VISIBILITY,    /*!< Visibility. */
     SAT_LIST_COL_DECAY,         /*!< Whether the satellite is decayed or not. */
+    SAT_LIST_COL_STAT_OPERATIONAL, /*!< Operational Status . */
     SAT_LIST_COL_BOLD,          /*!< Used to render the satellites above the horizon bold. */
     SAT_LIST_COL_NUMBER
 } sat_list_col_t;
@@ -134,7 +135,8 @@ typedef enum {
     SAT_LIST_FLAG_PHASE = 1 << SAT_LIST_COL_PHASE,      /*!< Phase. */
     SAT_LIST_FLAG_ORBIT = 1 << SAT_LIST_COL_ORBIT,      /*!< Orbit Number. */
     SAT_LIST_FLAG_VISIBILITY = 1 << SAT_LIST_COL_VISIBILITY,    /*!< Visibility. */
-    SAT_LIST_FLAG_DECAY = 1 << SAT_LIST_COL_DECAY       /*!< Decayed. */
+    SAT_LIST_FLAG_STAT_OPERATIONAL = 1 << SAT_LIST_COL_STAT_OPERATIONAL, /*!< Operational Status . */
+    SAT_LIST_FLAG_DECAY = 1 << SAT_LIST_COL_DECAY      /*!< Decayed. */
 } sat_list_flag_t;
 
 GType           gtk_sat_list_get_type(void);


### PR DESCRIPTION
Adds a checkbox for the operational status to be added to the list view.  I realize this information is (not obviously) available to the user by looking at the name suffixes, but for quick reference (ie, in a dashboard) it is helpful to have it in the list directly.

![2018-06-20-220644_2864x521_scrot](https://user-images.githubusercontent.com/6929725/41694050-4d1b126e-74d6-11e8-82c0-ba7a1e71dfef.png)
