### PR TITLE
WIP: Force Autotrack to respect minimum elevation setting

### DIFF
--- a/src/gtk-sat-module.c
+++ b/src/gtk-sat-module.c
@@ -81,12 +81,13 @@ static void update_autotrack(GtkSatModule * module)
     guint           i, n;
     double          next_aos;
     gint            next_sat;
+    int             min_ele = sat_cfg_get_int(SAT_CFG_INT_PRED_MIN_EL);
 
     if (module->target > 0)
         sat = g_hash_table_lookup(module->satellites, &module->target);
 
     /* do nothing if current target is still above horizon */
-    if (sat != NULL && sat->el > 0.0)
+    if (sat != NULL && sat->el > min_ele)
         return;
 
     /* set target to satellite with next AOS */
@@ -105,7 +106,7 @@ static void update_autotrack(GtkSatModule * module)
         sat = (sat_t *) iter->data;
 
         /* if sat is above horizon, select it and we are done */
-        if (sat->el > 0.0)
+        if (sat->el > min_ele)
         {
             next_sat = sat->tle.catnr;
             break;


### PR DESCRIPTION
In it's current iteration, auto track waits for the satellite to go to 0 elevation before moving on to the next one.

This is the simpler of the two fixes: have auto track use the global "min_el" setting used for prediction.  I ran this for a while, but realized I wanted a lot more control over the autotrack.

@csete we should talk about if this is good enough, or if you want to break autotrack out into it's own settings panel as I've done in: https://github.com/jasonuher/gpredict/tree/autotrack_settings

I'm currently going down the latter path for two reasons:
1) It was a good way to experiment with the way you're managing settings
2) I'm planning on adding a lot more to the autotrack feature (since I'm using this primarily as a passive dashboard, and not for active contesting or whatever)
  - Allow the user to choose switching parameter (range, path loss, az, el, etc)
  - Allow the user to configure the switching levels (ie, "el greater than 15", "az closest to my pointing vector", etc)

Thanks,
Jason (AB3RN)