### PR TITLE
Fix rotctl IO error handling to prevent fake feedback from rotator in GUI.

### DIFF
--- a/src/gtk-rot-ctrl.c
+++ b/src/gtk-rot-ctrl.c
@@ -323,6 +323,7 @@ static gboolean get_pos(GtkRotCtrl * ctrl, gdouble * az, gdouble * el)
             sat_log_log(SAT_LOG_LEVEL_ERROR,
                         _("%s:%d: rotctld returned error (%s)"),
                         __FILE__, __LINE__, buffback);
+            retcode = FALSE;
         }
         else
         {
@@ -338,6 +339,7 @@ static gboolean get_pos(GtkRotCtrl * ctrl, gdouble * az, gdouble * el)
                 sat_log_log(SAT_LOG_LEVEL_ERROR,
                             _("%s:%d: rotctld returned bad response (%s)"),
                             __FILE__, __LINE__, buffback);
+                retcode = FALSE;
             }
 
             g_strfreev(vbuff);
@@ -384,6 +386,7 @@ static gboolean set_pos(GtkRotCtrl * ctrl, gdouble az, gdouble el)
                         _
                         ("%s:%d: rotctld returned error %d with az %f el %f(%s)"),
                         __FILE__, __LINE__, retval, az, el, buffback);
+            retcode = FALSE;
         }
     }
 
@@ -437,7 +440,7 @@ static gpointer rotctld_client_thread(gpointer data)
         /* wait 100 ms before sending new command */
         g_usleep(100000);
         if (!get_pos(ctrl, &azi, &ele))
-            ctrl->client.io_error = TRUE;
+            io_error = TRUE;
 
         g_mutex_lock(&ctrl->client.mutex);
         ctrl->client.azi_in = azi;


### PR DESCRIPTION
We got an issue with rotator control GUI changing values in the Azimuth/Elevation "Read" fields as everything is OK, when actually rotator isn't moving due rotctld/hardware IO error. This little patch was enough to solve it for us.