### PR TITLE
Fix rotator controller on Windows, issue #128.

### DIFF
--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -1377,13 +1377,7 @@ static gboolean _send_rigctld_command(GtkRigCtrl * ctrl, gint sock, gchar * buff
     gint            written;
     gint            size;
 
-    /* added by Marcel Cimander; win32 newline -> \10\13 */
-#ifdef WIN32
-    size = strlen(buff) - 1;
-    /* added by Marcel Cimander; unix newline -> \10 (apple -> \13) */
-#else
     size = strlen(buff);
-#endif
 
     sat_log_log(SAT_LOG_LEVEL_DEBUG,
                 _("%s:%s: sending %d bytes to rigctld as \"%s\""),

--- a/src/gtk-rot-ctrl.c
+++ b/src/gtk-rot-ctrl.c
@@ -159,11 +159,7 @@ static gboolean rotctld_socket_rw(gint sock, gchar * buff, gchar * buffout,
     gint            written;
     gint            size;
 
-#ifdef WIN32
-    size = strlen(buff) - 1;
-#else
     size = strlen(buff);
-#endif
 
     /* send command */
     written = send(sock, buff, size, 0);

--- a/win32/config.mk
+++ b/win32/config.mk
@@ -15,7 +15,7 @@
 MINGW_ROOT=../../mingw32
 #MINGW_ROOT=../../../tmp/mingw32
 
-PKG_CONFIG_PATH = $(abspath $(MINGW_ROOT)/lib/pkgconfig)
+PKG_CONFIG_PATH = "$(abspath $(MINGW_ROOT)/lib/pkgconfig)"
 
 # binary dependencies to be deployed with gpredict.exe
 BINDEPS = \


### PR DESCRIPTION
I've tracked this hack down to https://github.com/rednamiC/gpredict_boinso_mod/commit/061d317f7154bdd42e7e0e6848b2a1c40c4bcc03.

All callers of the rotctld_socket_rw() are using "\x0a". So newline is 1 byte long already. After decrement we have commands without newline at all. Which isn't exactly complies with a protocol. I guess it does work for the get_pos() "p" command somehow, but doesn't for the set_pos() "P az el".

First commit is enough to fix issue #128. Radio control(gtk-rig-ctrl.c) seems to work ok on Windows with current master branch. So separate commit about _send_rigctld_command() is just to make things right.

Everything tested and checked on Windows 10 with MSYS2 and GDB/Eclipse CDT debugger.

Maybe it's better to switch from "\n" to "\x0a" in gtk-rig-ctrl.c:check_aos_los() for consistency. But I'm not sure it will break nothing on Windows.

Last commit is about me building gpredict on Windows with MSYS2 and username with spaces(that's crazy, I know).