### PR TITLE
Use gtk_spin_button_update() in gtk-sat-module-tmg.c:calculate_time().

### DIFF
--- a/src/gtk-sat-module-tmg.c
+++ b/src/gtk-sat-module-tmg.c
@@ -771,6 +771,12 @@ static gdouble calculate_time(GtkSatModule * mod)
     struct tm       tim, utim;
     gdouble         jd = 0.0;
 
+    /* update edited values in spin button's text entry */
+    gtk_spin_button_update(GTK_SPIN_BUTTON(mod->tmgHour));
+    gtk_spin_button_update(GTK_SPIN_BUTTON(mod->tmgMin));
+    gtk_spin_button_update(GTK_SPIN_BUTTON(mod->tmgSec));
+    gtk_spin_button_update(GTK_SPIN_BUTTON(mod->tmgMsec));
+
     /* get date and time from widgets */
     gtk_calendar_get_date(GTK_CALENDAR(mod->tmgCal), &year, &month, &day);
     hr = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(mod->tmgHour));


### PR DESCRIPTION
If user entered time from keyboard in Time Controller and clicked Play right after(without clicking plus/minus or other text entry, or focusing on another window in the middle) then entered value gets reverted back to previous. Which is a little bit annoying. Looks like gtk_spin_button_update() is appropriate to fix this behavior.