### PR TITLE
Fix timezone bug in epoch_to_str()

### DIFF
--- a/src/sat-info.c
+++ b/src/sat-info.c
@@ -232,13 +232,15 @@ static gchar   *epoch_to_str(sat_t * sat)
     fmt = sat_cfg_get_str(SAT_CFG_STR_TIME_FORMAT);
 
     /* format either local time or UTC depending on check box */
-    t = mktime(&tms);
     buff = g_try_malloc(51);
 
     if (sat_cfg_get_bool(SAT_CFG_BOOL_USE_LOCAL_TIME))
+    {
+        t = timegm(&tms);
         size = strftime(buff, 50, fmt, localtime(&t));
+    }
     else
-        size = strftime(buff, 50, fmt, gmtime(&t));
+        size = strftime(buff, 50, fmt, &tms);
 
     if (size < 50)
         buff[size] = '\0';


### PR DESCRIPTION
The function mktime() assumes that the struct tm is in local time,
whereas in this case it is in UTC time. A different approach must
be used to convert tms form UTC time to local time.