### PR TITLE
Add support for sending user-defined rigctrld commands on AOS, LOS or transponder tuning

### DIFF
--- a/src/radio-conf.c
+++ b/src/radio-conf.c
@@ -45,6 +45,8 @@
 #define KEY_VFO_UP      "VFO_UP"
 #define KEY_SIG_AOS     "SIGNAL_AOS"
 #define KEY_SIG_LOS     "SIGNAL_LOS"
+#define KEY_AOS_COMMAND "AOS_COMMAND"
+#define KEY_LOS_COMMAND "LOS_COMMAND"
 
 #define DEFAULT_CYCLE_MS    1000
 
@@ -237,6 +239,10 @@ gboolean radio_conf_read(radio_conf_t * conf)
     conf->signal_aos = g_key_file_get_boolean(cfg, GROUP, KEY_SIG_AOS, NULL);
     conf->signal_los = g_key_file_get_boolean(cfg, GROUP, KEY_SIG_LOS, NULL);
 
+    /* AOS and LOS commands */
+    conf->aos_command = g_key_file_get_string(cfg, GROUP, KEY_AOS_COMMAND, NULL);
+    conf->los_command = g_key_file_get_string(cfg, GROUP, KEY_LOS_COMMAND, NULL);
+
     g_key_file_free(cfg);
     sat_log_log(SAT_LOG_LEVEL_INFO,
                 _("%s: Read radio configuration %s"), __func__, conf->name);
@@ -288,6 +294,11 @@ void radio_conf_save(radio_conf_t * conf)
 
     g_key_file_set_boolean(cfg, GROUP, KEY_SIG_AOS, conf->signal_aos);
     g_key_file_set_boolean(cfg, GROUP, KEY_SIG_LOS, conf->signal_los);
+
+    if (conf->aos_command)
+        g_key_file_set_string(cfg, GROUP, KEY_AOS_COMMAND, conf->aos_command);
+    if (conf->los_command)
+        g_key_file_set_string(cfg, GROUP, KEY_LOS_COMMAND, conf->los_command);
 
     confdir = get_hwconf_dir();
     fname = g_strconcat(confdir, G_DIR_SEPARATOR_S, conf->name, ".rig", NULL);

--- a/src/radio-conf.h
+++ b/src/radio-conf.h
@@ -72,6 +72,9 @@ typedef struct {
 
     gboolean        signal_aos; /*!< Send AOS notification to RIG */
     gboolean        signal_los; /*!< Send LOS notification to RIG */
+
+    gchar          *aos_command; /*!< Commands to send to radio on AOS */
+    gchar          *los_command; /*!< Commands to send to radio on LOS */
 } radio_conf_t;
 
 

--- a/src/sat-pref-rig-data.h
+++ b/src/sat-pref-rig-data.h
@@ -40,6 +40,8 @@ typedef enum {
     RIG_LIST_COL_LOUP,          /*!< Local oscillato freq (uplink) */
     RIG_LIST_COL_SIGAOS,        /*!< Signal AOS */
     RIG_LIST_COL_SIGLOS,        /*!< Signal LOS */
+    RIG_LIST_COL_AOS_COMMAND,   /*!< AOS command */
+    RIG_LIST_COL_LOS_COMMAND,   /*!< LOS command */
     RIG_LIST_COL_NUM            /*!< The number of fields in the list. */
 } rig_list_col_t;
 

--- a/src/sat-pref-rig.c
+++ b/src/sat-pref-rig.c
@@ -61,7 +61,9 @@ static GtkTreeModel *create_and_fill_model()
                                    G_TYPE_DOUBLE,       // LO DOWN
                                    G_TYPE_DOUBLE,       // LO UO
                                    G_TYPE_BOOLEAN,      // AOS signalling
-                                   G_TYPE_BOOLEAN       // LOS signalling
+                                   G_TYPE_BOOLEAN,      // LOS signalling
+                                   G_TYPE_STRING,       // AOS command
+                                   G_TYPE_STRING        // LOS command
         );
 
     gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(liststore),
@@ -98,6 +100,8 @@ static GtkTreeModel *create_and_fill_model()
                                        RIG_LIST_COL_LOUP, conf.loup,
                                        RIG_LIST_COL_SIGAOS, conf.signal_aos,
                                        RIG_LIST_COL_SIGLOS, conf.signal_los,
+                                       RIG_LIST_COL_AOS_COMMAND, conf.aos_command,
+                                       RIG_LIST_COL_LOS_COMMAND, conf.los_command,
                                        -1);
 
                     sat_log_log(SAT_LOG_LEVEL_DEBUG,
@@ -426,7 +430,10 @@ static void edit_cb(GtkWidget * button, gpointer data)
                            RIG_LIST_COL_LO, &conf.lo,
                            RIG_LIST_COL_LOUP, &conf.loup,
                            RIG_LIST_COL_SIGAOS, &conf.signal_aos,
-                           RIG_LIST_COL_SIGLOS, &conf.signal_los, -1);
+                           RIG_LIST_COL_SIGLOS, &conf.signal_los,
+                           RIG_LIST_COL_AOS_COMMAND, &conf.aos_command,
+                           RIG_LIST_COL_LOS_COMMAND, &conf.los_command,
+                           -1);
     }
     else
     {
@@ -462,7 +469,10 @@ static void edit_cb(GtkWidget * button, gpointer data)
                            RIG_LIST_COL_LO, conf.lo,
                            RIG_LIST_COL_LOUP, conf.loup,
                            RIG_LIST_COL_SIGAOS, conf.signal_aos,
-                           RIG_LIST_COL_SIGLOS, conf.signal_los, -1);
+                           RIG_LIST_COL_SIGLOS, conf.signal_los,
+                           RIG_LIST_COL_AOS_COMMAND, conf.aos_command,
+                           RIG_LIST_COL_LOS_COMMAND, conf.los_command,
+                           -1);
     }
 
     /* clean up memory */
@@ -609,8 +619,31 @@ static void create_rig_list()
                                             (RIG_LIST_COL_SIGLOS), NULL);
     gtk_tree_view_insert_column(GTK_TREE_VIEW(riglist), column, -1);
 
+
+    /* AOS command */
+    renderer = gtk_cell_renderer_text_new();
+    column = gtk_tree_view_column_new_with_attributes(_("AOS Command"),
+                                                     renderer,
+                                                     "text",
+                                                     RIG_LIST_COL_AOS_COMMAND,
+                                                     NULL);
+    gtk_tree_view_insert_column(GTK_TREE_VIEW(riglist), column, -1);
+
+    /* LOS command */
+    renderer = gtk_cell_renderer_text_new();
+    column = gtk_tree_view_column_new_with_attributes(_("LOS Command"),
+                                                      renderer,
+                                                     "text",
+                                                     RIG_LIST_COL_LOS_COMMAND,
+                                                     NULL);
+    gtk_tree_view_insert_column(GTK_TREE_VIEW(riglist), column, -1);
+
+
+
+
     g_signal_connect(riglist, "row-activated", G_CALLBACK(row_activated_cb),
                      riglist);
+
 }
 
 /**
@@ -690,6 +723,8 @@ static void add_cb(GtkWidget * button, gpointer data)
         .loup = 0.0,
         .signal_aos = FALSE,
         .signal_los = FALSE,
+        .aos_command = NULL,
+        .los_command = NULL
     };
 
     /* run rig conf editor */
@@ -712,7 +747,10 @@ static void add_cb(GtkWidget * button, gpointer data)
                            RIG_LIST_COL_LO, conf.lo,
                            RIG_LIST_COL_LOUP, conf.loup,
                            RIG_LIST_COL_SIGAOS, conf.signal_aos,
-                           RIG_LIST_COL_SIGLOS, conf.signal_los, -1);
+                           RIG_LIST_COL_SIGLOS, conf.signal_los,
+                           RIG_LIST_COL_AOS_COMMAND, conf.aos_command,
+                           RIG_LIST_COL_LOS_COMMAND, conf.los_command,
+                           -1);
 
         g_free(conf.name);
 
@@ -813,7 +851,9 @@ void sat_pref_rig_ok()
         .lo = 0.0,
         .loup = 0.0,
         .signal_aos = FALSE,
-        .signal_los = FALSE
+        .signal_los = FALSE,
+        .aos_command = NULL,
+        .los_command = NULL
     };
 
     /* delete all .rig files */
@@ -859,7 +899,10 @@ void sat_pref_rig_ok()
                                RIG_LIST_COL_LO, &conf.lo,
                                RIG_LIST_COL_LOUP, &conf.loup,
                                RIG_LIST_COL_SIGAOS, &conf.signal_aos,
-                               RIG_LIST_COL_SIGLOS, &conf.signal_los, -1);
+                               RIG_LIST_COL_SIGLOS, &conf.signal_los,
+                               RIG_LIST_COL_AOS_COMMAND, &conf.aos_command,
+                               RIG_LIST_COL_LOS_COMMAND, &conf.los_command,
+                               -1);
             radio_conf_save(&conf);
 
             /* free conf buffer */

--- a/src/trsp-conf.c
+++ b/src/trsp-conf.c
@@ -40,6 +40,7 @@
 #define KEY_INVERT      "INVERT"
 #define KEY_MODE        "MODE"
 #define KEY_BAUD        "BAUD"
+#define KEY_COMMAND     "COMMAND"
 
 static void check_trsp_freq(trsp_t * trsp)
 {
@@ -180,7 +181,6 @@ GSList *read_transponders(guint catnum)
                         name, groups[i]);
             g_clear_error(&error);
         }
-
         trsp->baud = g_key_file_get_double(cfg, groups[i], KEY_BAUD, &error);
         if (error != NULL)
         {
@@ -188,6 +188,15 @@ GSList *read_transponders(guint catnum)
                         name, groups[i]);
             g_clear_error(&error);
         }
+
+        trsp->command = g_key_file_get_string(cfg, groups[i], KEY_COMMAND, &error);
+        if (error != NULL)
+        {
+            sat_log_log(SAT_LOG_LEVEL_INFO, INFO_MSG, __func__, KEY_COMMAND,
+                        name, groups[i]);
+            g_clear_error(&error);
+        }
+
 
         /* add transponder to list */
         trsplist = g_slist_append(trsplist, trsp);
@@ -254,6 +263,8 @@ void write_transponders(guint catnum, GSList * trsp_list)
             g_key_file_set_boolean(trsp_data, trsp->name, KEY_INVERT, TRUE);
         if (trsp->mode)
             g_key_file_set_string(trsp_data, trsp->name, KEY_MODE, trsp->name);
+        if (trsp->command)
+            g_key_file_set_string(trsp_data, trsp->name, KEY_COMMAND, trsp->command);
     }
 
     if (gpredict_save_key_file(trsp_data, trsp_file))

--- a/src/trsp-conf.h
+++ b/src/trsp-conf.h
@@ -39,6 +39,7 @@ typedef struct {
     gdouble         baud;       /*!< Baud rate > */
     gboolean        invert;     /*!< Flag indicating whether transponder is inverting. */
     gchar          *mode;       /*!< Mode descriptor. */
+    gchar          *command;    /*!< Command(s) to send to radio when selecting this transponder. */
 } trsp_t;
 
 /* The actual data would then be a singly linked list with pointers to transponder_t structures */


### PR DESCRIPTION
This patch adds the ability for a user to define a ; separated list of rigctrld commands to be sent to the radio on AOS or LOS. E.g. set_powerstat 0/1 to turn on/off the radio.

It also adds the ability to send a user-defined command when tuning to a transponder. This allows the appropriate mode, bandwidth and antenna to be set automatically. E.g. set_mode FM, 10000 ; set_ant 0

The AOS/LOS commands can be defined in the GUI. Currently, the transponder commands need to be defined in the .trsp file, with the COMMAND key. E.g:

33591.trsp
[APT Downlink]
DOWN_LOW=137100000
MODE=APT
COMMAND=set_mode WFM, 40000;set_ant 0

Eventually this should be added to the GUI, but I thought I'd see if this patch was agreed to first.

This feature was requested in Issue #182 