### PR TITLE
Stop map buffer leaking

### DIFF
--- a/src/gtk-sat-map-ground-track.c
+++ b/src/gtk-sat-map-ground-track.c
@@ -411,6 +411,7 @@ static void create_polylines(GtkSatMap * satmap, sat_t * sat, qth_t * qth,
                 lasty = ssp->lon;
             }
             /* else do nothing */
+            else g_free(ssp);
         }
     }
 

--- a/src/gtk-sat-map.c
+++ b/src/gtk-sat-map.c
@@ -2016,7 +2016,7 @@ static void free_sat_obj(gpointer key, gpointer value, gpointer data)
 
     if (obj->showtrack)
     {
-        sat = SAT(g_hash_table_lookup(satmap->sats, &obj->catnr));
+        sat = SAT(g_hash_table_lookup(satmap->sats, &obj->catnum));
         ground_track_delete(satmap, sat, satmap->qth, obj, TRUE);
     }
 }

--- a/src/gtk-sat-map.h
+++ b/src/gtk-sat-map.h
@@ -65,6 +65,7 @@ typedef struct {
     /* book keeping */
     guint           oldrcnum;   /*!< Number of RC parts in prev. cycle. */
     guint           newrcnum;   /*!< Number of RC parts in this cycle. */
+    gint            catnum;     /*!< Catalogue number of satellite. */
 
     ground_track_t  track_data; /*!< Ground track data. */
     long            track_orbit;        /*!< Orbit when the ground track has been updated. */

--- a/src/gtk-sat-module.c
+++ b/src/gtk-sat-module.c
@@ -134,6 +134,8 @@ static void update_autotrack(GtkSatModule * module)
 static void gtk_sat_module_destroy(GtkWidget * widget)
 {
     GtkSatModule   *module = GTK_SAT_MODULE(widget);
+    GtkWidget      *view;
+    guint           i;
 
     /*save the configuration */
     mod_cfg_save(module->name, module->cfgdata);
@@ -168,6 +170,14 @@ static void gtk_sat_module_destroy(GtkWidget * widget)
         gtk_widget_destroy(module->skgwin);
     }
 
+    /* destroy views */
+    for (i = 0; i < module->nviews; i++)
+    {
+        view = GTK_WIDGET(g_slist_nth_data(module->views, i));
+        gtk_widget_destroy(view);
+    }
+    module->nviews = 0;
+
     /* clean up QTH */
     if (module->qth)
     {
@@ -187,8 +197,6 @@ static void gtk_sat_module_destroy(GtkWidget * widget)
         g_free(module->grid);
         module->grid = NULL;
     }
-
-    /* FIXME: free module->views? */
 
     (*GTK_WIDGET_CLASS(parent_class)->destroy) (widget);
 }

--- a/src/gtk-sat-module.c
+++ b/src/gtk-sat-module.c
@@ -1256,7 +1256,7 @@ void gtk_sat_module_config_cb(GtkWidget * button, gpointer data)
     }
     else
     {
-        module->timerid = -1;
+        module->timerid = 0;
         retcode = mod_cfg_edit(name, module->cfgdata, toplevel);
         if (retcode == MOD_CFG_OK)
         {

--- a/src/gtk-sat-module.c
+++ b/src/gtk-sat-module.c
@@ -1377,16 +1377,6 @@ void gtk_sat_module_config_cb(GtkWidget * button, gpointer data)
     g_free(name);
 }
 
-static gboolean empty(gpointer key, gpointer val, gpointer data)
-{
-    (void)key;
-    (void)val;
-    (void)data;
-
-    /* TRUE => sat removed from hash table */
-    return TRUE;
-}
-
 /** Reload satellites in view */
 static void reload_sats_in_child(GtkWidget * widget, GtkSatModule * module)
 {
@@ -1447,7 +1437,7 @@ void gtk_sat_module_reload_sats(GtkSatModule * module)
                 __func__, module->name);
 
     /* remove each element from the hash table, but keep the hash table */
-    g_hash_table_foreach_remove(module->satellites, empty, NULL);
+    g_hash_table_remove_all(module->satellites);
 
     /* reset event counter so that next AOS/LOS gets re-calculated */
     module->event_count = 0;


### PR DESCRIPTION
Taking a look at memory with valgrind, I found that the map pixel buffer was not deallocated. When configuring the module, the map gets re-created and another buffer leaks. I beefed up the destructor to clean up both the map and the objects associated with satellites. I had to add a reference to the `sat_t` in `sat_map_obj_t` as in #223 so that the ground track can be deleted.

A second (minor) issue that tripped me up while debugging is the `timerid` in GtkSatModule. GSource IDs are unsigned, but always greater than `0`. [See g_source_get_id.](https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html#g-source-get-id) Setting it to `-1` means it passes the `>0` test in `gtk_sat_module_destroy` and the timer gets removed a second time.