### PR TITLE
docs: fix simple typo, predicition -> prediction

### DIFF
--- a/src/gtk-polar-plot.c
+++ b/src/gtk-polar-plot.c
@@ -28,7 +28,7 @@
  *
  * GtkPolarPlot is a graphical widget that can display a satellite pass
  * in an Az/El polar plot. The widget was originally created to display
- * a single satellite pass in the detailed pass predicition dialog.
+ * a single satellite pass in the detailed pass prediction dialog.
  * 
  * Later, a few utility functions were added in order to make the GtkPolarPlot
  * more dynamic and useful in other contexts too. In addition to a satellite


### PR DESCRIPTION
There is a small typo in src/gtk-polar-plot.c.

Should read `prediction` rather than `predicition`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md