### PR TITLE
Add select popup menu option to use selected sat in the rig/antenna control windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ m4/
 GTAGS
 GRTAGS
 GPATH
+.autotools
+.cproject
+.project
+.settings

--- a/src/gtk-event-list.c
+++ b/src/gtk-event-list.c
@@ -197,7 +197,7 @@ static void gtk_event_list_destroy(GtkWidget * widget)
  * @param qth Pointer to the QTH used by this module.
  * @param columns Visible columns (currently not in use).
  */
-GtkWidget      *gtk_event_list_new(GKeyFile * cfgdata, GHashTable * sats,
+GtkWidget      *gtk_event_list_new(GtkWidget * module, GKeyFile * cfgdata, GHashTable * sats,
                                    qth_t * qth, guint32 columns)
 {
     GtkWidget      *widget;
@@ -212,6 +212,7 @@ GtkWidget      *gtk_event_list_new(GKeyFile * cfgdata, GHashTable * sats,
     widget = g_object_new(GTK_TYPE_EVENT_LIST, NULL);
     evlist = GTK_EVENT_LIST(widget);
 
+    evlist->satmod = module;
     evlist->update = gtk_event_list_update;
 
     evlist->cfgdata = cfgdata;

--- a/src/gtk-event-list.h
+++ b/src/gtk-event-list.h
@@ -31,6 +31,7 @@ typedef struct _GtkEventListClass GtkEventListClass;
 struct _gtk_event_list {
     GtkBox          box;
 
+    GtkWidget      *satmod;	    /*!< The parent GtkSatModule widget */
     GtkWidget      *treeview;   /*!< the tree view itself */
     GtkWidget      *swin;       /*!< scrolled window */
 
@@ -77,7 +78,7 @@ typedef enum {
 } event_list_flag_t;
 
 GType           gtk_event_list_get_type(void);
-GtkWidget      *gtk_event_list_new(GKeyFile * cfgdata,
+GtkWidget      *gtk_event_list_new(GtkWidget * module, GKeyFile * cfgdata,
                                    GHashTable * sats,
                                    qth_t * qth, guint32 columns);
 void            gtk_event_list_update(GtkWidget * widget);

--- a/src/gtk-polar-view.c
+++ b/src/gtk-polar-view.c
@@ -760,7 +760,7 @@ static GooCanvasItemModel *create_canvas_model(GtkPolarView * polv)
  * @param sats Pointer to the hash table containing the asociated satellites.
  * @param qth Pointer to the ground station data.
  */
-GtkWidget      *gtk_polar_view_new(GKeyFile * cfgdata, GHashTable * sats,
+GtkWidget      *gtk_polar_view_new(GtkWidget * module, GKeyFile * cfgdata, GHashTable * sats,
                                    qth_t * qth)
 {
     GtkPolarView       *polv;
@@ -768,6 +768,7 @@ GtkWidget      *gtk_polar_view_new(GKeyFile * cfgdata, GHashTable * sats,
 
     polv = GTK_POLAR_VIEW(g_object_new(GTK_TYPE_POLAR_VIEW, NULL));
 
+    polv->satmod = module;
     polv->cfgdata = cfgdata;
     polv->sats = sats;
     polv->qth = qth;

--- a/src/gtk-polar-view.h
+++ b/src/gtk-polar-view.h
@@ -67,6 +67,7 @@ typedef enum {
 struct _GtkPolarView {
     GtkBox          vbox;
 
+    GtkWidget      *satmod;	    /*!< The parent GtkSatModule widget */
     GtkWidget      *canvas;     /*!< The canvas widget */
 
     GooCanvasItemModel *bgd;
@@ -117,7 +118,7 @@ struct _GtkPolarViewClass {
 
 GType           gtk_polar_view_get_type(void);
 
-GtkWidget      *gtk_polar_view_new(GKeyFile * cfgdata,
+GtkWidget      *gtk_polar_view_new(GtkWidget * module, GKeyFile * cfgdata,
                                    GHashTable * sats, qth_t * qth);
 void            gtk_polar_view_update(GtkWidget * widget);
 void            gtk_polar_view_reconf(GtkWidget * widget, GKeyFile * cfgdat);

--- a/src/gtk-sat-list.c
+++ b/src/gtk-sat-list.c
@@ -280,7 +280,7 @@ static void gtk_sat_list_destroy(GtkWidget * widget)
     (*GTK_WIDGET_CLASS(parent_class)->destroy) (widget);
 }
 
-GtkWidget      *gtk_sat_list_new(GKeyFile * cfgdata, GHashTable * sats,
+GtkWidget      *gtk_sat_list_new(GtkWidget * module, GKeyFile * cfgdata, GHashTable * sats,
                                  qth_t * qth, guint32 columns)
 {
 //    GtkWidget      *widget;
@@ -295,6 +295,7 @@ GtkWidget      *gtk_sat_list_new(GKeyFile * cfgdata, GHashTable * sats,
 //    widget = g_object_new(GTK_TYPE_SAT_LIST, NULL);
     satlist = GTK_SAT_LIST(g_object_new(GTK_TYPE_SAT_LIST, NULL));
 
+    satlist->satmod = module;
     satlist->update = gtk_sat_list_update;
 
     /* Read configuration data. */

--- a/src/gtk-sat-list.h
+++ b/src/gtk-sat-list.h
@@ -52,6 +52,8 @@ typedef struct _GtkSatListClass GtkSatListClass;
 struct _gtk_sat_list {
     GtkBox          vbox;
 
+    GtkWidget      *satmod;	    /*!< The parent GtkSatModule widget */
+
     GtkWidget      *treeview;   /*!< the tree view itself */
     GtkWidget      *swin;       /*!< scrolled window */
 
@@ -140,7 +142,7 @@ typedef enum {
 } sat_list_flag_t;
 
 GType           gtk_sat_list_get_type(void);
-GtkWidget      *gtk_sat_list_new(GKeyFile * cfgdata,
+GtkWidget      *gtk_sat_list_new(GtkWidget * module, GKeyFile * cfgdata,
                                  GHashTable * sats,
                                  qth_t * qth, guint32 columns);
 void            gtk_sat_list_update(GtkWidget * widget);

--- a/src/gtk-sat-map.c
+++ b/src/gtk-sat-map.c
@@ -280,7 +280,7 @@ static void gtk_sat_map_destroy(GtkWidget * widget)
     (*GTK_WIDGET_CLASS(parent_class)->destroy) (widget);
 }
 
-GtkWidget      *gtk_sat_map_new(GKeyFile * cfgdata, GHashTable * sats,
+GtkWidget      *gtk_sat_map_new(GtkWidget * module, GKeyFile * cfgdata, GHashTable * sats,
                                 qth_t * qth)
 {
     GtkSatMap      *satmap;
@@ -289,6 +289,7 @@ GtkWidget      *gtk_sat_map_new(GKeyFile * cfgdata, GHashTable * sats,
 
     satmap = g_object_new(GTK_TYPE_SAT_MAP, NULL);
 
+    satmap->satmod = module;
     satmap->cfgdata = cfgdata;
     satmap->sats = sats;
     satmap->qth = qth;

--- a/src/gtk-sat-map.h
+++ b/src/gtk-sat-map.h
@@ -78,6 +78,7 @@ typedef struct {
 typedef struct {
     GtkBox          vbox;
 
+    GtkWidget      *satmod;	    /*!< The parent GtkSatModule widget */
     GtkWidget      *canvas;     /*!< The canvas widget. */
 
     GooCanvasItemModel *map;    /*!< The canvas map item. */
@@ -141,7 +142,7 @@ struct _GtkSatMapClass {
 };
 
 GType           gtk_sat_map_get_type(void);
-GtkWidget      *gtk_sat_map_new(GKeyFile * cfgdata,
+GtkWidget      *gtk_sat_map_new(GtkWidget * module, GKeyFile * cfgdata,
                                 GHashTable * sats, qth_t * qth);
 void            gtk_sat_map_update(GtkWidget * widget);
 void            gtk_sat_map_reconf(GtkWidget * widget, GKeyFile * cfgdat);

--- a/src/gtk-sat-module.c
+++ b/src/gtk-sat-module.c
@@ -303,27 +303,27 @@ static GtkWidget *create_view(GtkSatModule * module, guint num)
     switch (num)
     {
     case GTK_SAT_MOD_VIEW_LIST:
-        view = gtk_sat_list_new(module->cfgdata,
+        view = gtk_sat_list_new(GTK_WIDGET(module), module->cfgdata,
                                 module->satellites, module->qth, 0);
         break;
 
     case GTK_SAT_MOD_VIEW_MAP:
-        view = gtk_sat_map_new(module->cfgdata,
+        view = gtk_sat_map_new(GTK_WIDGET(module), module->cfgdata,
                                module->satellites, module->qth);
         break;
 
     case GTK_SAT_MOD_VIEW_POLAR:
-        view = gtk_polar_view_new(module->cfgdata,
+        view = gtk_polar_view_new(GTK_WIDGET(module), module->cfgdata,
                                   module->satellites, module->qth);
         break;
 
     case GTK_SAT_MOD_VIEW_SINGLE:
-        view = gtk_single_sat_new(module->cfgdata,
+        view = gtk_single_sat_new(GTK_WIDGET(module), module->cfgdata,
                                   module->satellites, module->qth, 0);
         break;
 
     case GTK_SAT_MOD_VIEW_EVENT:
-        view = gtk_event_list_new(module->cfgdata,
+        view = gtk_event_list_new(GTK_WIDGET(module), module->cfgdata,
                                   module->satellites, module->qth, 0);
         break;
 
@@ -332,7 +332,7 @@ static GtkWidget *create_view(GtkSatModule * module, guint num)
                     _("%s:%d: Invalid child type (%d). Using GtkSatList."),
                     __FILE__, __LINE__, num);
 
-        view = gtk_sat_list_new(module->cfgdata,
+        view = gtk_sat_list_new(GTK_WIDGET(module), module->cfgdata,
                                 module->satellites, module->qth, 0);
         break;
     }

--- a/src/gtk-sat-popup-common.c
+++ b/src/gtk-sat-popup-common.c
@@ -21,6 +21,13 @@
 #include <gtk/gtk.h>
 
 #include "gtk-sat-popup-common.h"
+#include "gtk-sat-module.h"
+#include "gtk-event-list.h"
+#include "gtk-polar-view.h"
+#include "gtk-sat-map.h"
+#include "gtk-single-sat.h"
+#include "gtk-sat-list.h"
+#include "sat-log.h"
 #include "orbit-tools.h"
 #include "predict-tools.h"
 #include "sat-cfg.h"
@@ -53,12 +60,21 @@ void add_pass_menu_items(GtkWidget * menu, sat_t * sat, qth_t * qth,
                      widget);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 
-    /* finally the future pass menu item */
+    /* the future pass menu item */
     menuitem = gtk_menu_item_new_with_label(_("Future passes"));
     g_object_set_data(G_OBJECT(menuitem), "sat", sat);
     g_object_set_data(G_OBJECT(menuitem), "qth", qth);
     g_object_set_data(G_OBJECT(menuitem), "tstamp", tstamp);
     g_signal_connect(menuitem, "activate", G_CALLBACK(show_future_passes_cb),
+                     widget);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
+
+    /* finally the select menu item */
+    menuitem = gtk_menu_item_new_with_label(_("Select"));
+    g_object_set_data(G_OBJECT(menuitem), "sat", sat);
+    g_object_set_data(G_OBJECT(menuitem), "qth", qth);
+    g_object_set_data(G_OBJECT(menuitem), "tstamp", tstamp);
+    g_signal_connect(menuitem, "activate", G_CALLBACK(sat_select_cb),
                      widget);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 }
@@ -112,6 +128,48 @@ void show_future_passes_cb(GtkWidget * menuitem, gpointer data)
     tstamp = (gdouble *) (g_object_get_data(G_OBJECT(menuitem), "tstamp"));
 
     show_future_passes_dialog(sat, qth, *tstamp, toplevel);
+}
+
+void sat_select_cb(GtkWidget * menuitem, gpointer data)
+{
+    sat_t          *sat;
+    GtkWidget      *satmod;
+
+    if (IS_GTK_SAT_LIST(data))
+    {
+        satmod = GTK_SAT_LIST(data)->satmod;
+    }
+
+    else if (IS_GTK_SAT_MAP(data))
+    {
+        satmod = GTK_SAT_MAP(data)->satmod;
+    }
+
+    else if (IS_GTK_POLAR_VIEW(data))
+    {
+        satmod = GTK_POLAR_VIEW(data)->satmod;
+    }
+
+    else if (IS_GTK_SINGLE_SAT(data))
+    {
+        satmod = GTK_SINGLE_SAT(data)->satmod;
+    }
+
+    else if (IS_GTK_EVENT_LIST(data))
+    {
+        satmod = GTK_EVENT_LIST(data)->satmod;
+    }
+
+    else
+    {
+        sat_log_log(SAT_LOG_LEVEL_ERROR,
+                    _("%s:%d: Unknown data type"), __FILE__, __LINE__);
+        return;
+    }
+
+    sat = SAT(g_object_get_data(G_OBJECT(menuitem), "sat"));
+
+    gtk_sat_module_select_sat(GTK_SAT_MODULE(satmod), sat->tle.catnr);
 }
 
 void show_next_pass_dialog(sat_t * sat, qth_t * qth, gdouble tstamp,

--- a/src/gtk-sat-popup-common.h
+++ b/src/gtk-sat-popup-common.h
@@ -15,5 +15,6 @@ void            show_next_pass_dialog(sat_t * sat, qth_t * qth,
 void            show_future_passes_dialog(sat_t * sat, qth_t * qth,
                                           gdouble tstamp,
                                           GtkWindow * toplevel);
+void			sat_select_cb(GtkWidget * menuitem, gpointer data);
 
 #endif

--- a/src/gtk-single-sat.c
+++ b/src/gtk-single-sat.c
@@ -707,7 +707,7 @@ GType gtk_single_sat_get_type()
     return gtk_single_sat_type;
 }
 
-GtkWidget      *gtk_single_sat_new(GKeyFile * cfgdata, GHashTable * sats,
+GtkWidget      *gtk_single_sat_new(GtkWidget * module, GKeyFile * cfgdata, GHashTable * sats,
                                    qth_t * qth, guint32 fields)
 {
     GtkWidget      *widget;
@@ -725,6 +725,7 @@ GtkWidget      *gtk_single_sat_new(GKeyFile * cfgdata, GHashTable * sats,
                                    GTK_ORIENTATION_VERTICAL);
     single_sat = GTK_SINGLE_SAT(widget);
 
+    single_sat->satmod = module;
     single_sat->update = gtk_single_sat_update;
 
     /* Read configuration data. */

--- a/src/gtk-single-sat.h
+++ b/src/gtk-single-sat.h
@@ -84,6 +84,7 @@ typedef struct _GtkSingleSatClass GtkSingleSatClass;
 struct _gtk_single_sat {
     GtkBox          vbox;
 
+    GtkWidget      *satmod;	    /*!< The parent GtkSatModule widget */
     GtkWidget      *header;     /*!< Header label, ie. satellite name. */
 
     GtkWidget      *labels[SINGLE_SAT_FIELD_NUMBER];    /*!< GtkLabels displaying the data. */
@@ -114,7 +115,7 @@ struct _GtkSingleSatClass {
 };
 
 GType           gtk_single_sat_get_type(void);
-GtkWidget      *gtk_single_sat_new(GKeyFile * cfgdata,
+GtkWidget      *gtk_single_sat_new(GtkWidget * module, GKeyFile * cfgdata,
                                    GHashTable * sats,
                                    qth_t * qth, guint32 fields);
 void            gtk_single_sat_update(GtkWidget * widget);


### PR DESCRIPTION
This PR adds a new "Select" popup menu item, which lets the user easily select a satellite for tracking in the rig and antenna control windows by just using the right click popup menu on a satellite.