### PR TITLE
Add internationalization to gtk-freq-knob decimal separator

### DIFF
--- a/src/compat.c
+++ b/src/compat.c
@@ -27,6 +27,7 @@
 #endif
 #include <glib.h>
 #include <stdlib.h>
+#include <locale.h>
 #include "compat.h"
 
 /**
@@ -395,4 +396,17 @@ gchar          *hw_file_name(const gchar * hwfile)
     g_free(buff);
 
     return filename;
+}
+
+gchar const* get_locale_thousands_sep()
+{
+	struct lconv *locale;
+
+	locale = localeconv();
+
+	if (!locale) {
+		return NULL;
+	}
+
+	return locale->thousands_sep;
 }

--- a/src/compat.h
+++ b/src/compat.h
@@ -23,4 +23,6 @@ gchar          *hw_file_name(const gchar * hwfile);
 gchar          *sat_file_name_from_catnum(guint catnum);
 gchar          *sat_file_name_from_catnum_s(gchar * catnum);
 
+gchar    const* get_locale_thousands_sep();
+
 #endif

--- a/src/gtk-freq-knob.c
+++ b/src/gtk-freq-knob.c
@@ -24,6 +24,7 @@
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 #include <math.h>
+#include "compat.h"
 #include "gtk-freq-knob.h"
 
 
@@ -316,7 +317,11 @@ GtkWidget      *gtk_freq_knob_new(gdouble val, gboolean buttons)
     GtkWidget      *label;
     guint           i;
     gint            delta;
-
+    const gchar     beginTag[] = "<span size='xx-large'>";
+    const gchar     endTag[] = "</span>";
+    gchar          *markup = NULL;
+    size_t          markupBufSize;
+    const gchar    *thousandsSep = get_locale_thousands_sep();
 
     widget = g_object_new(GTK_TYPE_FREQ_KNOB, NULL);
     knob = GTK_FREQ_KNOB(widget);
@@ -389,12 +394,24 @@ GtkWidget      *gtk_freq_knob_new(gdouble val, gboolean buttons)
     }
 
     /* Add misc labels */
+    markupBufSize = strlen(beginTag) + strlen(endTag) +
+                                 strlen(thousandsSep) + 1;
+    markup = (char*) malloc(sizeof(char)*markupBufSize);
+    if (markup && thousandsSep) {
+        snprintf(markup, markupBufSize, "%s%s%s", beginTag, thousandsSep, endTag);
+    } else {
+        markup = "<span size='xx-large'>.</span>";
+    }
     label = gtk_label_new(NULL);
-    gtk_label_set_markup(GTK_LABEL(label), "<span size='xx-large'>.</span>");
+    gtk_label_set_markup(GTK_LABEL(label), markup);
     gtk_grid_attach(GTK_GRID(table), label, 5, 1, 1, 1);
     label = gtk_label_new(NULL);
-    gtk_label_set_markup(GTK_LABEL(label), "<span size='xx-large'>.</span>");
+    gtk_label_set_markup(GTK_LABEL(label), markup);
     gtk_grid_attach(GTK_GRID(table), label, 9, 1, 1, 1);
+
+    if (markup) {
+        free(markup);
+    }
 
     label = gtk_label_new(NULL);
     gtk_label_set_markup(GTK_LABEL(label), "<span size='xx-large'> Hz</span>");


### PR DESCRIPTION
Previously, the thousands place separator for gtk-freq-knob was hard-coded as the decimal point (".").

Make the following changes:

- Modify gtk-freq-knob.c to mark this string for translation.
- Add "translations" for each currently supported language.

Translations are made according to [the Wikipedia article on decimal point separators](https://en.wikipedia.org/wiki/Decimal_separator).

| Comma      | Decimal point
| -----------|--------------
| UK English | Czech
| US English | Danish
| Thai       | German
|            | Greek
|            | Spanish
|            | Finnish
|            | French
|            | Indonesian
|            | Italian
|            | Lithuanian
|            | Russian
|            | Ukrainian

To keep the commit from being overly large, even though the actual delta of the .po files was quite large (as these have not been updated in 3 years), I added to the commit only the POT generation time change and the addition of the "numeric thousands separator" translations.