### PR TITLE
Allow configuring default frequencies per radio

### DIFF
--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -859,6 +859,16 @@ static void primary_rig_selected_cb(GtkComboBox * box, gpointer data)
             gtk_label_set_text(GTK_LABEL(ctrl->LoUp), buff);
             g_free(buff);
         }
+
+        /* update frequency widgets */
+        gtk_freq_knob_set_value(GTK_FREQ_KNOB(ctrl->SatFreqDown),
+                                ctrl->conf->defDnFreq);
+        if (gtk_combo_box_get_active(GTK_COMBO_BOX(ctrl->DevSel2)) == 0)
+        {
+            gtk_freq_knob_set_value(GTK_FREQ_KNOB(ctrl->SatFreqUp),
+                                    ctrl->conf->defUpFreq);
+        }
+
     }
     else
     {
@@ -905,6 +915,10 @@ static void secondary_rig_selected_cb(GtkComboBox * box, gpointer data)
             g_free(buff);
         }
 
+        /* reset uplink frequency to what's in ctrl->conf */
+        gtk_freq_knob_set_value(GTK_FREQ_KNOB(ctrl->SatFreqUp),
+                                ctrl->conf->defUpFreq);
+
         return;
     }
 
@@ -925,6 +939,10 @@ static void secondary_rig_selected_cb(GtkComboBox * box, gpointer data)
             g_free(buff);
         }
         gtk_combo_box_set_active(GTK_COMBO_BOX(ctrl->DevSel2), 0);
+
+        /* update frequency widgets */
+        gtk_freq_knob_set_value(GTK_FREQ_KNOB(ctrl->SatFreqUp),
+                                ctrl->conf->defUpFreq);
 
         return;
     }

--- a/src/radio-conf.c
+++ b/src/radio-conf.c
@@ -39,6 +39,8 @@
 #define KEY_CYCLE       "Cycle"
 #define KEY_LO          "LO"
 #define KEY_LOUP        "LO_UP"
+#define KEY_DEF_UP_FREQ "DefaultUplinkFreqHz"
+#define KEY_DEF_DN_FREQ "DefaultDownlinkFreqHz"
 #define KEY_TYPE        "Type"
 #define KEY_PTT         "PTT"
 #define KEY_VFO_DOWN    "VFO_DOWN"
@@ -175,6 +177,46 @@ gboolean radio_conf_read(radio_conf_t * conf)
         conf->loup = 0.0;
     }
 
+    /* KEY_DEF_UP_FREQ is optional */
+    if (g_key_file_has_key(cfg, GROUP, KEY_DEF_UP_FREQ, NULL))
+    {
+        conf->defUpFreq =
+            g_key_file_get_double(cfg, GROUP, KEY_DEF_UP_FREQ, &error);
+        if (error != NULL)
+        {
+            sat_log_log(SAT_LOG_LEVEL_ERROR,
+                        _("%s: Error reading radio conf from %s (%s)."),
+                        __func__, conf->name, error->message);
+            g_clear_error(&error);
+            g_key_file_free(cfg);
+            return FALSE;
+        }
+    }
+    else
+    {
+        conf->defUpFreq = 145890000.0;
+    }
+
+    /* KEY_DEF_DN_FREQ is optional */
+    if (g_key_file_has_key(cfg, GROUP, KEY_DEF_DN_FREQ, NULL))
+    {
+        conf->defDnFreq =
+            g_key_file_get_double(cfg, GROUP, KEY_DEF_DN_FREQ, &error);
+        if (error != NULL)
+        {
+            sat_log_log(SAT_LOG_LEVEL_ERROR,
+                        _("%s: Error reading radio conf from %s (%s)."),
+                        __func__, conf->name, error->message);
+            g_clear_error(&error);
+            g_key_file_free(cfg);
+            return FALSE;
+        }
+    }
+    else
+    {
+        conf->defDnFreq = 145890000.0;
+    }
+
     /* Radio type */
     conf->type = g_key_file_get_integer(cfg, GROUP, KEY_TYPE, &error);
     if (error != NULL)
@@ -272,6 +314,8 @@ void radio_conf_save(radio_conf_t * conf)
     g_key_file_set_integer(cfg, GROUP, KEY_PORT, conf->port);
     g_key_file_set_double(cfg, GROUP, KEY_LO, conf->lo);
     g_key_file_set_double(cfg, GROUP, KEY_LOUP, conf->loup);
+    g_key_file_set_double(cfg, GROUP, KEY_DEF_UP_FREQ, conf->defUpFreq);
+    g_key_file_set_double(cfg, GROUP, KEY_DEF_DN_FREQ, conf->defDnFreq);
     g_key_file_set_integer(cfg, GROUP, KEY_TYPE, conf->type);
     g_key_file_set_integer(cfg, GROUP, KEY_PTT, conf->ptt);
 

--- a/src/radio-conf.h
+++ b/src/radio-conf.h
@@ -65,6 +65,8 @@ typedef struct {
     gdouble         lo;         /*!< local oscillator freq in Hz (using double for
                                    compatibility with rest of code). Downlink. */
     gdouble         loup;       /*!< local oscillator freq in Hz for uplink. */
+    gdouble         defUpFreq;  /*!< Default uplink in Hertz */
+    gdouble         defDnFreq;  /*!< Default downlink frequency in Hertz */
     rig_type_t      type;       /*!< Radio type */
     ptt_type_t      ptt;        /*!< PTT type (needed for RX, TX, and TRX) */
     vfo_t           vfoDown;    /*!< Downlink VFO for full-duplex radios */

--- a/src/sat-pref-rig-data.h
+++ b/src/sat-pref-rig-data.h
@@ -38,6 +38,8 @@ typedef enum {
     RIG_LIST_COL_VFODOWN,       /*!< VFO down */
     RIG_LIST_COL_LO,            /*!< Local oscillator freq (downlink) */
     RIG_LIST_COL_LOUP,          /*!< Local oscillato freq (uplink) */
+    RIG_LIST_COL_DEF_UP_FREQ,   /*!< Default uplink frequency */
+    RIG_LIST_COL_DEF_DN_FREQ,   /*!< Default downlink frequency */
     RIG_LIST_COL_SIGAOS,        /*!< Signal AOS */
     RIG_LIST_COL_SIGLOS,        /*!< Signal LOS */
     RIG_LIST_COL_NUM            /*!< The number of fields in the list. */

--- a/src/sat-pref-rig-editor.c
+++ b/src/sat-pref-rig-editor.c
@@ -41,6 +41,8 @@ static GtkWidget *ptt;          /* PTT */
 static GtkWidget *vfo;          /* VFO Up/Down selector */
 static GtkWidget *lo;           /* local oscillator of downconverter */
 static GtkWidget *loup;         /* local oscillator of upconverter */
+static GtkWidget *defDnFreq;    /* Default downlink frequency */
+static GtkWidget *defUpFreq;    /* Default uplink frequency */
 static GtkWidget *sigaos;       /* AOS signalling */
 static GtkWidget *siglos;       /* LOS signalling */
 
@@ -52,6 +54,8 @@ static void clear_widgets()
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(port), 4532);     /* hamlib default? */
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(lo), 0);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(loup), 0);
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(defDnFreq), 145.89);
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(defUpFreq), 145.89);
     gtk_combo_box_set_active(GTK_COMBO_BOX(type), RIG_TYPE_RX);
     gtk_combo_box_set_active(GTK_COMBO_BOX(ptt), PTT_TYPE_NONE);
     gtk_combo_box_set_active(GTK_COMBO_BOX(vfo), 0);
@@ -99,6 +103,14 @@ static void update_widgets(radio_conf_t * conf)
 
     /* lo up in MHz */
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(loup), conf->loup / 1000000.0);
+
+    /* Default downlink frequency in MHz */
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(defDnFreq),
+                              conf->defDnFreq * 1.0e-6);
+
+    /* Default uplink frequency in Mhz */
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(defUpFreq),
+                              conf->defUpFreq * 1.0e-6);
 
     /* AOS / LOS signalling */
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(sigaos), conf->signal_aos);
@@ -421,18 +433,50 @@ static GtkWidget *create_editor_widgets(radio_conf_t * conf)
     g_object_set(label, "xalign", 0.0, "yalign", 0.5, NULL);
     gtk_grid_attach(GTK_GRID(table), label, 3, 7, 1, 1);
 
-    /* AOS / LOS signalling */
-    label = gtk_label_new(_("Signalling"));
+    /* Default downlink frequency */
+    label = gtk_label_new(_("Default downlink"));
     g_object_set(label, "xalign", 1.0, "yalign", 0.5, NULL);
     gtk_grid_attach(GTK_GRID(table), label, 0, 8, 1, 1);
 
+    defDnFreq = gtk_spin_button_new_with_range(0, 10000, 0.001);
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(defDnFreq), 0);
+    gtk_spin_button_set_digits(GTK_SPIN_BUTTON(defDnFreq), 3);
+    gtk_widget_set_tooltip_text(defDnFreq,
+                                _("Enter the default downlink frequency"));
+    gtk_grid_attach(GTK_GRID(table), defDnFreq, 1, 8, 2, 1);
+
+    label = gtk_label_new(_("MHz"));
+    g_object_set(label, "xalign", 0.0, "yalign", 0.5, NULL);
+    gtk_grid_attach(GTK_GRID(table), label, 3, 8, 1, 1);
+
+    /* Default uplink frequency */
+    label = gtk_label_new(_("Default uplink"));
+    g_object_set(label, "xalign", 1.0, "yalign", 0.5, NULL);
+    gtk_grid_attach(GTK_GRID(table), label, 0, 9, 1, 1);
+
+    defUpFreq = gtk_spin_button_new_with_range(0, 10000, 0.001);
+    gtk_spin_button_set_digits(GTK_SPIN_BUTTON(defUpFreq), 3);
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(defUpFreq), 123.456);
+    gtk_widget_set_tooltip_text(defUpFreq,
+                                _("Enter the default uplink frequency"));
+    gtk_grid_attach(GTK_GRID(table), defUpFreq, 1, 9, 2, 1);
+
+    label = gtk_label_new(_("MHz"));
+    g_object_set(label, "xalign", 0.0, "yalign", 0.5, NULL);
+    gtk_grid_attach(GTK_GRID(table), label, 3, 9, 1, 1);
+
+    /* AOS / LOS signalling */
+    label = gtk_label_new(_("Signalling"));
+    g_object_set(label, "xalign", 1.0, "yalign", 0.5, NULL);
+    gtk_grid_attach(GTK_GRID(table), label, 0, 10, 1, 1);
+
     sigaos = gtk_check_button_new_with_label(_("AOS"));
-    gtk_grid_attach(GTK_GRID(table), sigaos, 1, 8, 1, 1);
+    gtk_grid_attach(GTK_GRID(table), sigaos, 1, 10, 1, 1);
     gtk_widget_set_tooltip_text(sigaos,
                                 _("Enable AOS signalling for this radio."));
 
     siglos = gtk_check_button_new_with_label(_("LOS"));
-    gtk_grid_attach(GTK_GRID(table), siglos, 2, 8, 1, 1);
+    gtk_grid_attach(GTK_GRID(table), siglos, 2, 10, 1, 1);
     gtk_widget_set_tooltip_text(siglos,
                                 _("Enable LOS signalling for this radio."));
 
@@ -467,6 +511,14 @@ static gboolean apply_changes(radio_conf_t * conf)
 
     /* lo up freq */
     conf->loup = 1000000.0 * gtk_spin_button_get_value(GTK_SPIN_BUTTON(loup));
+
+    /* default downlink freq */
+    conf->defDnFreq = 1000000.0 *
+                      gtk_spin_button_get_value(GTK_SPIN_BUTTON(defDnFreq));
+
+    /* default uplink freq */
+    conf->defUpFreq = 1000000.0 *
+                      gtk_spin_button_get_value(GTK_SPIN_BUTTON(defUpFreq));
 
     /* rig type */
     conf->type = gtk_combo_box_get_active(GTK_COMBO_BOX(type));

--- a/src/sat-pref-rig.c
+++ b/src/sat-pref-rig.c
@@ -60,6 +60,8 @@ static GtkTreeModel *create_and_fill_model()
                                    G_TYPE_INT,  // VFO Down
                                    G_TYPE_DOUBLE,       // LO DOWN
                                    G_TYPE_DOUBLE,       // LO UO
+                                   G_TYPE_DOUBLE,       // Default down freq.
+                                   G_TYPE_DOUBLE,       // Default up freq.
                                    G_TYPE_BOOLEAN,      // AOS signalling
                                    G_TYPE_BOOLEAN       // LOS signalling
         );
@@ -96,6 +98,8 @@ static GtkTreeModel *create_and_fill_model()
                                        RIG_LIST_COL_VFODOWN, conf.vfoDown,
                                        RIG_LIST_COL_LO, conf.lo,
                                        RIG_LIST_COL_LOUP, conf.loup,
+                                       RIG_LIST_COL_DEF_UP_FREQ, conf.defUpFreq,
+                                       RIG_LIST_COL_DEF_DN_FREQ, conf.defDnFreq,
                                        RIG_LIST_COL_SIGAOS, conf.signal_aos,
                                        RIG_LIST_COL_SIGLOS, conf.signal_los,
                                        -1);
@@ -293,7 +297,7 @@ static void render_lo(GtkTreeViewColumn * col,
 
     /* convert to MHz */
     number /= 1000000.0;
-    buff = g_strdup_printf("%.0f MHz", number);
+    buff = g_strdup_printf("%.3f MHz", number);
     g_object_set(renderer, "text", buff, NULL);
     g_free(buff);
 }
@@ -393,6 +397,8 @@ static void edit_cb(GtkWidget * button, gpointer data)
         .vfoDown = 0,
         .lo = 0.0,
         .loup = 0.0,
+        .defUpFreq = 0.0,
+        .defDnFreq = 0.0,
         .signal_aos = FALSE,
         .signal_los = FALSE
     };
@@ -425,6 +431,8 @@ static void edit_cb(GtkWidget * button, gpointer data)
                            RIG_LIST_COL_VFODOWN, &conf.vfoDown,
                            RIG_LIST_COL_LO, &conf.lo,
                            RIG_LIST_COL_LOUP, &conf.loup,
+                           RIG_LIST_COL_DEF_UP_FREQ, &conf.defUpFreq,
+                           RIG_LIST_COL_DEF_DN_FREQ, &conf.defDnFreq,
                            RIG_LIST_COL_SIGAOS, &conf.signal_aos,
                            RIG_LIST_COL_SIGLOS, &conf.signal_los, -1);
     }
@@ -461,6 +469,8 @@ static void edit_cb(GtkWidget * button, gpointer data)
                            RIG_LIST_COL_VFODOWN, conf.vfoDown,
                            RIG_LIST_COL_LO, conf.lo,
                            RIG_LIST_COL_LOUP, conf.loup,
+                           RIG_LIST_COL_DEF_UP_FREQ, conf.defUpFreq,
+                           RIG_LIST_COL_DEF_DN_FREQ, conf.defDnFreq,
                            RIG_LIST_COL_SIGAOS, conf.signal_aos,
                            RIG_LIST_COL_SIGLOS, conf.signal_los, -1);
     }
@@ -587,6 +597,27 @@ static void create_rig_list()
                                             (RIG_LIST_COL_LOUP), NULL);
     gtk_tree_view_insert_column(GTK_TREE_VIEW(riglist), column, -1);
 
+    /* Default downlink frequency */
+    renderer = gtk_cell_renderer_text_new();
+    column = gtk_tree_view_column_new_with_attributes(_("Downlink"), renderer,
+                                                      "text", RIG_LIST_COL_DEF_DN_FREQ,
+                                                      NULL);
+    gtk_tree_view_column_set_cell_data_func(column, renderer,
+                                            render_lo,
+                                            GUINT_TO_POINTER(RIG_LIST_COL_DEF_DN_FREQ),
+                                            NULL);
+    gtk_tree_view_insert_column(GTK_TREE_VIEW(riglist), column, -1);
+
+    /* Default uplink frequency */
+    renderer = gtk_cell_renderer_text_new();
+    column = gtk_tree_view_column_new_with_attributes(_("Uplink"), renderer,
+                                                      "text",
+                                                      RIG_LIST_COL_DEF_UP_FREQ, NULL);
+    gtk_tree_view_column_set_cell_data_func(column, renderer, render_lo,
+                                            GUINT_TO_POINTER
+                                            (RIG_LIST_COL_DEF_UP_FREQ), NULL);
+    gtk_tree_view_insert_column(GTK_TREE_VIEW(riglist), column, -1);
+
     /* AOS signalling */
     renderer = gtk_cell_renderer_text_new();
     column =
@@ -688,6 +719,8 @@ static void add_cb(GtkWidget * button, gpointer data)
         .vfoDown = 0,
         .lo = 0.0,
         .loup = 0.0,
+        .defDnFreq = 14589000.0,
+        .defUpFreq = 14589000.0,
         .signal_aos = FALSE,
         .signal_los = FALSE,
     };
@@ -711,6 +744,8 @@ static void add_cb(GtkWidget * button, gpointer data)
                            RIG_LIST_COL_VFODOWN, conf.vfoDown,
                            RIG_LIST_COL_LO, conf.lo,
                            RIG_LIST_COL_LOUP, conf.loup,
+                           RIG_LIST_COL_DEF_UP_FREQ, conf.defUpFreq,
+                           RIG_LIST_COL_DEF_DN_FREQ, conf.defDnFreq,
                            RIG_LIST_COL_SIGAOS, conf.signal_aos,
                            RIG_LIST_COL_SIGLOS, conf.signal_los, -1);
 
@@ -812,6 +847,8 @@ void sat_pref_rig_ok()
         .vfoDown = 0,
         .lo = 0.0,
         .loup = 0.0,
+        .defDnFreq = 14589000.0,
+        .defUpFreq = 14589000.0,
         .signal_aos = FALSE,
         .signal_los = FALSE
     };
@@ -858,6 +895,8 @@ void sat_pref_rig_ok()
                                RIG_LIST_COL_VFODOWN, &conf.vfoDown,
                                RIG_LIST_COL_LO, &conf.lo,
                                RIG_LIST_COL_LOUP, &conf.loup,
+                               RIG_LIST_COL_DEF_UP_FREQ, &conf.defUpFreq,
+                               RIG_LIST_COL_DEF_DN_FREQ, &conf.defDnFreq,
                                RIG_LIST_COL_SIGAOS, &conf.signal_aos,
                                RIG_LIST_COL_SIGLOS, &conf.signal_los, -1);
             radio_conf_save(&conf);


### PR DESCRIPTION
- Add controls to the rig editor dialog box to allow setting a default uplink and downlink frequency for each radio (rig).
- Read and write rig uplink and downlink frequency to the rig configuration files
- Display the default uplink and downlink frequency as columns in the rig list.