### PR TITLE
Fix spelling

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,7 +62,7 @@ Changes in version 2.0 (10 Dec 2017)
 - Fixed track button in rotator controller having no effect
 - Fixed operational status of satellites
 - Fixed wrong icon in time controller
-- Fixed mising ground track for new satellites
+- Fixed missing ground track for new satellites
 - Fixed show next pass shows the current pass
 - Fixed problems with plotting footprints near the poles
 - Fixed satellite nickname not escaped for Pango

--- a/doc/notes/ic-910.txt
+++ b/doc/notes/ic-910.txt
@@ -8,7 +8,7 @@ CI-V transceive: On
 
 
 When the radio is connected to the PC via the CI-V CAT Interface and serial port COM1 it is
-on /dev/ttyS0 or higer number.
+on /dev/ttyS0 or higher number.
 When you are using a usb-serial-rs232-adapter it should be on /dev/ttyUSB0 or higher number.
 
 

--- a/doc/notes/ic-9100.txt
+++ b/doc/notes/ic-9100.txt
@@ -8,7 +8,7 @@ CI-V transceive: On
 
 
 When the radio is connected to the PC via the CI-V CAT Interface and serial port COM1 it is
-on /dev/ttyS0 or higer number.
+on /dev/ttyS0 or higher number.
 When you are using a usb-serial-rs232-adapter it should be on /dev/ttyUSB0 or higher number.
 
 

--- a/doc/notes/ic-9700.txt
+++ b/doc/notes/ic-9700.txt
@@ -15,7 +15,7 @@ When the radio is connected to the PC you should see:
 
 $ lsmod |grep cp
 
-cp210x                 24576 << is the kernel module and memory size, if compiled into the kernel you wont see the module but may still work, try below.
+cp210x                 24576 << is the kernel module and memory size, if compiled into the kernel you won't see the module but may still work, try below.
 
 $ lsusb
 

--- a/doc/notes/time_keeping.txt
+++ b/doc/notes/time_keeping.txt
@@ -9,7 +9,7 @@ difference between these two with the number of minutes per day:
 
 tsince = (sat->jul_utc - sat->jul_epoch) * xmnpd
 
-Similiarly, when predicting passes, a specific Julian date can be obtained from
+Similarly, when predicting passes, a specific Julian date can be obtained from
 tsince by dividing tsince with the number of minutes per day and adding the
 Epoch time as Julian date to it:
 

--- a/src/first-time.c
+++ b/src/first-time.c
@@ -86,9 +86,9 @@ static void     first_time_check_step_08(guint * error);
  * Send both error, warning and verbose debug messages to sat-log during this
  * process.
  *
- * The function returns 0 if everything seems to be ready or 1 if an error occured
+ * The function returns 0 if everything seems to be ready or 1 if an error occurred
  * during on of the steps above. In case of error, the only safe thing is to exit
- * imediately.
+ * immediately.
  *
  * FIXME: Should only have one parameterized function for checking directories.
  */
@@ -584,7 +584,7 @@ static void create_cat_files(guint * error)
             if (g_str_has_suffix(filename, ".cat"))
             {
 
-                /* check whether .cat file exisits in user conf */
+                /* check whether .cat file exists in user conf */
                 gchar          *catfilename = sat_file_name(filename);
 
                 if (!g_file_test(catfilename, G_FILE_TEST_EXISTS))

--- a/src/gpredict-utils.c
+++ b/src/gpredict-utils.c
@@ -149,7 +149,7 @@ static void set_combo_tooltip(GtkWidget * combo, gpointer text)
  * Actually, this function only loops over all the children of the GtkComboBox
  * and calls the set_combo_tooltip internal function.
  *
- * @note This works only if the funcion is actually used as callback for the
+ * @note This works only if the function is actually used as callback for the
  *       @a realize signal og the GtkComboBox.
  *
  * @note This great trick has been pointed out by Matthias Clasen, he has done the

--- a/src/gtk-azel-plot.c
+++ b/src/gtk-azel-plot.c
@@ -614,7 +614,7 @@ static GooCanvasItemModel *create_canvas_model(GtkAzelPlot * azel)
 /**
  * Create a new GtkAzelPlot widget.
  * @param cfgdata The configuration data of the parent module.
- * @param sats Pointer to the hash table containing the asociated satellites.
+ * @param sats Pointer to the hash table containing the associated satellites.
  * @param qth Pointer to the ground station data.
  */
 GtkWidget      *gtk_azel_plot_new(qth_t * qth, pass_t * pass)

--- a/src/gtk-event-list.c
+++ b/src/gtk-event-list.c
@@ -539,7 +539,7 @@ static void check_and_set_cell_renderer(GtkTreeViewColumn * column,
 }
 
 /**
- * Render column containg event type.
+ * Render column containing event type.
  *
  * Event type can be AOS or LOS depending on whether the satellite is within
  * range or not. AOS will rendern an "A", LOS will render an "L".

--- a/src/gtk-polar-view.c
+++ b/src/gtk-polar-view.c
@@ -757,7 +757,7 @@ static GooCanvasItemModel *create_canvas_model(GtkPolarView * polv)
  * Create a new GtkPolarView widget.
  *
  * @param cfgdata The configuration data of the parent module.
- * @param sats Pointer to the hash table containing the asociated satellites.
+ * @param sats Pointer to the hash table containing the associated satellites.
  * @param qth Pointer to the ground station data.
  */
 GtkWidget      *gtk_polar_view_new(GKeyFile * cfgdata, GHashTable * sats,

--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -351,7 +351,7 @@ static void track_downlink(GtkRigCtrl * ctrl)
     if (ctrl->trsp == NULL)
         return;
 
-    /* ensure that we have a useable transponder config */
+    /* ensure that we have a usable transponder config */
     if ((ctrl->trsp->downlow > 0) && (ctrl->trsp->uplow > 0))
     {
         down = gtk_freq_knob_get_value(GTK_FREQ_KNOB(ctrl->SatFreqDown));
@@ -377,7 +377,7 @@ static void track_uplink(GtkRigCtrl * ctrl)
     if (ctrl->trsp == NULL)
         return;
 
-    /* ensure that we have a useable transponder config */
+    /* ensure that we have a usable transponder config */
     if ((ctrl->trsp->downlow > 0) && (ctrl->trsp->uplow > 0))
     {
         up = gtk_freq_knob_get_value(GTK_FREQ_KNOB(ctrl->SatFreqUp));
@@ -2302,7 +2302,7 @@ static gboolean set_ptt(GtkRigCtrl * ctrl, gint sock, gboolean ptt)
  *         occurred.
  *
  * This function checks whether AOS or LOS just happened and sends the
- * apropriate signal to the RIG if this signalling is enabled.
+ * appropriate signal to the RIG if this signalling is enabled.
  */
 static gboolean check_aos_los(GtkRigCtrl * ctrl)
 {
@@ -2514,7 +2514,7 @@ static gboolean get_freq_toggle(GtkRigCtrl * ctrl, gint sock, gdouble * freq)
  * TRUE (on). If PTT status is TRUE (on) it will simply set the PTT to FALSE
  * (off).
  *
- * This function assumes that the radio supprot set/get PTT, otherwise it makes
+ * This function assumes that the radio support set/get PTT, otherwise it makes
  * no sense to use it!
  */
 static void manage_ptt_event(GtkRigCtrl * ctrl)

--- a/src/gtk-rig-ctrl.h
+++ b/src/gtk-rig-ctrl.h
@@ -91,7 +91,7 @@ struct _gtk_rig_ctrl {
     /* threads related stuff */
     /* add mutexes etc, to make threads reentrant! */
     GMutex          writelock;  /*!< Mutex for blocking write operation */
-    GMutex          rig_ctrl_updatelock;        /*!< Mutex wile updating widgets etc */
+    GMutex          rig_ctrl_updatelock;        /*!< Mutex while updating widgets etc */
     GMutex          widgetsync; /*!< Mutex used while leaving (sync stuff) */
     GCond           widgetready;        /*!< Condition when work is done (sync stuff) */
     GAsyncQueue    *rigctlq;    /*!< Message queue to indicate something has changed */

--- a/src/gtk-rot-knob.c
+++ b/src/gtk-rot-knob.c
@@ -359,7 +359,7 @@ gdouble gtk_rot_knob_get_min(GtkRotKnob * knob)
  */
 void gtk_rot_knob_set_min(GtkRotKnob * knob, gdouble min)
 {
-    /* just som sanity check we have only 3 digits */
+    /* just some sanity check we have only 3 digits */
     if (min < 1000)
     {
         knob->min = min;
@@ -381,7 +381,7 @@ void gtk_rot_knob_set_min(GtkRotKnob * knob, gdouble min)
  */
 void gtk_rot_knob_set_max(GtkRotKnob * knob, gdouble max)
 {
-    /* just som sanity check we have only 3 digits */
+    /* just some sanity check we have only 3 digits */
     if (max < 1000)
     {
         knob->max = max;

--- a/src/gtk-sat-data.c
+++ b/src/gtk-sat-data.c
@@ -44,7 +44,7 @@
  *
  * @param catnum The catalog number of the satellite.
  * @param sat Pointer to a valid sat_t structure.
- * @return 0 if successfull, 1 if an I/O error occurred,
+ * @return 0 if successful, 1 if an I/O error occurred,
  *         2 if the TLE data appears to be bad.
  *
  */

--- a/src/gtk-sat-list.c
+++ b/src/gtk-sat-list.c
@@ -941,14 +941,14 @@ static void     operational_status_cell_data_function(GtkTreeViewColumn * col,
 
 }
 
-/* Render column containg lat/lon
+/* Render column containing lat/lon
    by using this instead of the default data function, we can
    control the number of decimals and display the coordinates in a
    fancy way, including degree sign and NWSE suffixes.
 
    Please note that this function only affects how the numbers are
    displayed (rendered), the tree_store will still contain the
-   original flaoting point numbers. Very cool!
+   original floating point numbers. Very cool!
 */
 static void latlon_cell_data_function(GtkTreeViewColumn * col,
                                       GtkCellRenderer * renderer,

--- a/src/gtk-sat-map-ground-track.c
+++ b/src/gtk-sat-map-ground-track.c
@@ -61,7 +61,7 @@ static void     free_ssp(gpointer ssp, gpointer data);
  * @param obj the satellite object.
  *  
  * Gpredict allows the user to require the ground track for any number of orbits
- * ahead. Therfore, the resulting ground track may cross the map boundaries many
+ * ahead. Therefore, the resulting ground track may cross the map boundaries many
  * times, and using one single polyline for the whole ground track would look very
  * silly. To avoid this, the points will be split into several polylines.
  */
@@ -156,7 +156,7 @@ void ground_track_create(GtkSatMap * satmap, sat_t * sat, qth_t * qth,
     }
 
     /* Reset satellite structure to eliminate glitches in single sat 
-       view and other places when new ground track is layed out */
+       view and other places when new ground track is laid out */
     predict_calc(sat, qth, satmap->tstamp);
 
     /* reverse GSList */

--- a/src/gtk-sat-map.c
+++ b/src/gtk-sat-map.c
@@ -1294,7 +1294,7 @@ static gboolean mirror_lon(sat_t * sat, gdouble rangelon, gdouble * mlon,
  * This function calculates the "left" side of the range circle and mirrors
  * the points in longitude to create the "right side of the range circle, too.
  * In order to be able to use the footprint points to create a set of subsequent
- * lines conencted to each other (poly-lines) the function may have to perform
+ * lines connected to each other (poly-lines) the function may have to perform
  * one of the following three actions:
  *
  * 1. If the footprint covers the North or South pole, we need to sort the points

--- a/src/gtk-sat-module-popup.c
+++ b/src/gtk-sat-module-popup.c
@@ -455,7 +455,7 @@ static void docking_state_cb(GtkWidget * menuitem, gpointer data)
 
     case GTK_SAT_MOD_STATE_WINDOW:
     case GTK_SAT_MOD_STATE_FULLSCREEN:
-        /* increase referene count */
+        /* increase reference count */
         g_object_ref(module);
 
         /* reparent time manager window if visible */
@@ -803,7 +803,7 @@ static void rigctrl_cb(GtkWidget * menuitem, gpointer data)
 
     if (module->rigctrl == NULL)
     {
-        /* gtk_rig_ctrl_new returned NULL becasue no radios are configured */
+        /* gtk_rig_ctrl_new returned NULL because no radios are configured */
         GtkWidget      *dialog;
 
         dialog = gtk_message_dialog_new(GTK_WINDOW(app),
@@ -882,7 +882,7 @@ static void rotctrl_cb(GtkWidget * menuitem, gpointer data)
 
     if (module->rotctrl == NULL)
     {
-        /* gtk_rot_ctrl_new returned NULL becasue no rotators are configured */
+        /* gtk_rot_ctrl_new returned NULL because no rotators are configured */
         GtkWidget      *dialog;
 
         dialog = gtk_message_dialog_new(GTK_WINDOW(app),

--- a/src/gtk-sat-module-tmg.c
+++ b/src/gtk-sat-module-tmg.c
@@ -480,7 +480,7 @@ static void tmg_time_set(GtkWidget * widget, gpointer data)
  * @param data Pointer to the GtkSatModule structure.
  *
  * This function is called when the user moves the slider.
- * If we are in manual control mode, the function simpley calls
+ * If we are in manual control mode, the function simply calls
  * tmg_time_set(). In the other modes, the function switches over
  * to amnual mode first.
  */
@@ -704,7 +704,7 @@ void tmg_update_widgets(GtkSatModule * mod)
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(mod->tmgMin), tim.tm_min);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(mod->tmgSec), tim.tm_sec);
 
-    /* msec: alway 0 in RT and SRT modes */
+    /* msec: always 0 in RT and SRT modes */
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(mod->tmgMsec), 0);
 
     /* calendar */
@@ -746,7 +746,7 @@ static void tmg_cal_add_one_day(GtkSatModule * mod)
     tmg_update_widgets(mod);
 }
 
-/** Substract one day from the calendar */
+/** Subtract one day from the calendar */
 static void tmg_cal_sub_one_day(GtkSatModule * mod)
 {
     gdouble         jd;

--- a/src/gtk-sat-module.c
+++ b/src/gtk-sat-module.c
@@ -622,7 +622,7 @@ static void update_child(GtkWidget * child, gdouble tstamp)
  * @param val The hash table value (sat_t structure)
  * @param data User data (the GtkSatModule widget).
  *
- * This function updates the tracking data for a given satelite. It is called by
+ * This function updates the tracking data for a given satellite. It is called by
  * the timeout handler for each element in the hash table.
  */
 static void gtk_sat_module_update_sat(gpointer key, gpointer val,
@@ -663,7 +663,7 @@ static void gtk_sat_module_update_sat(gpointer key, gpointer val,
 
        daynum is the current time in the module.
 
-       The conditional aos < daynum is merely saying that aos occured
+       The conditional aos < daynum is merely saying that aos occurred
        in the past. Therefore it cannot be the next event or aos/los
        for that satellite.
 
@@ -1163,7 +1163,7 @@ void gtk_sat_module_close_cb(GtkWidget * button, gpointer data)
                         __func__, name, retcode);
         }
 
-        /* increase referene count */
+        /* increase reference count */
         g_object_ref(module);
 
         /* remove module from window, destroy window */
@@ -1193,7 +1193,7 @@ void gtk_sat_module_close_cb(GtkWidget * button, gpointer data)
         }
 
 
-        /* increase referene count */
+        /* increase reference count */
         g_object_ref(module);
 
         /* remove module from window, destroy window */
@@ -1214,7 +1214,7 @@ void gtk_sat_module_close_cb(GtkWidget * button, gpointer data)
         break;
     }
 
-    /* appearantly, module will be destroyed when removed from notebook */
+    /* apparently, module will be destroyed when removed from notebook */
     /* gtk_widget_destroy (GTK_WIDGET (module)); */
     sat_log_log(SAT_LOG_LEVEL_INFO,
                 _("%s: Module %s closed."), __func__, name);
@@ -1229,7 +1229,7 @@ void gtk_sat_module_close_cb(GtkWidget * button, gpointer data)
  * @param data Pointer the GtkSatModule widget, which should be reconfigured
  *
  * This function is called when the user clicks on the "configure" minibutton.
- * The function incokes the mod_cfg_edit funcion, which has the same look and feel
+ * The function incokes the mod_cfg_edit function, which has the same look and feel
  * as the dialog used to create a new module.
  *
  * NOTE: Don't use button, since we don't know what kind of widget it is

--- a/src/gtk-sat-selector.c
+++ b/src/gtk-sat-selector.c
@@ -154,7 +154,7 @@ static void search_icon_clicked(GtkEntry *entry, GtkEntryIconPosition icon_pos,
  *
  * @param view Pointer to the GtkTreeView object.
  * @param path The path of the row that was activated.
- * @param column The column where the activation occured.
+ * @param column The column where the activation occurred.
  * @param data Pointer to the GtkSatselector widget.
  *
  * This function is called when the user double clicks on a satellite in the
@@ -912,7 +912,7 @@ gdouble gtk_sat_selector_get_latest_epoch(GtkSatSelector * selector)
  * Search through all the models for the given satellite and set its selected value.
  *
  * @param *selector is the selector that contains the models
- * @param catnr is the catalog numer of satellite.
+ * @param catnr is the catalog number of satellite.
  * @param val is true or false depending on whether that satellite is selected or not.
  */
 static void gtk_sat_selector_mark_engine(GtkSatSelector * selector, gint catnr,
@@ -950,7 +950,7 @@ static void gtk_sat_selector_mark_engine(GtkSatSelector * selector, gint catnr,
  * Search the models for the satellite and set SELECTED to TRUE.
  *
  * @param *selector is the selector that contains the models
- * @param catnr is the catalog numer of satellite.
+ * @param catnr is the catalog number of satellite.
  */
 void gtk_sat_selector_mark_selected(GtkSatSelector * selector, gint catnr)
 {
@@ -961,7 +961,7 @@ void gtk_sat_selector_mark_selected(GtkSatSelector * selector, gint catnr)
  * Searches the models for the satellite and sets SELECTED to FALSE.
  *
  * @param *selector is the selector that contains the models
- * @param catnr is the catalog numer of satellite.
+ * @param catnr is the catalog number of satellite.
  *
  */
 void gtk_sat_selector_mark_unselected(GtkSatSelector * selector, gint catnr)

--- a/src/gtk-sat-tree.c
+++ b/src/gtk-sat-tree.c
@@ -426,7 +426,7 @@ static gint scan_tle_file(const gchar * path, GtkTreeStore * store,
             i++;
         }
 
-        /* close IO chanel; don't care about status */
+        /* close IO channel; don't care about status */
         g_io_channel_shutdown(tlefile, TRUE, NULL);
         g_io_channel_unref(tlefile);
     }
@@ -572,7 +572,7 @@ void gtk_sat_tree_select(GtkSatTree * sat_tree, guint catnum)
  * @param path The GtkTreePath of the current item.
  * @param iter The GtkTreeIter of the current item.
  * @param data Pointer to the GtkSatTree structure.
- * @return Alway FALSE to let the for-each run to till end.
+ * @return Always FALSE to let the for-each run to till end.
  *
  * This function is used as foreach-callback in the gtk_sat_tree_select function.
  * The purpoise of the function is to set the check box to chacked state and add
@@ -637,7 +637,7 @@ static gboolean check_and_select_sat(GtkTreeModel * model,
  * @param path The GtkTreePath of the current item.
  * @param iter The GtkTreeIter of the current item.
  * @param data Pointer to the GtkSatTree structure.
- * @return Alway FALSE to let the for-each run to till end.
+ * @return Always FALSE to let the for-each run to till end.
  *
  * This function is very similar to the check_and_select callback except that it
  * is used only to uncheck a deselected satellite.

--- a/src/gtk-sky-glance.c
+++ b/src/gtk-sky-glance.c
@@ -771,7 +771,7 @@ static void create_sat(gpointer key, gpointer value, gpointer data)
 /**
  * Create a new GtkSkyGlance widget.
  *
- * @param sats Pointer to the hash table containing the asociated satellites.
+ * @param sats Pointer to the hash table containing the associated satellites.
  * @param qth Pointer to the ground station data.
  * @param ts The t0 for the timeline or 0 to use the current date and time.
  */

--- a/src/loc-tree.c
+++ b/src/loc-tree.c
@@ -106,7 +106,7 @@ gboolean loc_tree_create(const gchar * fname,
        Note that there are several ways to create and add the individual
        columns, especially there are tree_view_insert_col functions, which
        do not require explicit creation of columns. I have chosen to
-       explicitly ceate the columns in order to be able to hide them
+       explicitly create the columns in order to be able to hide them
        according to the flags parameter.
      */
 
@@ -395,7 +395,7 @@ static GtkTreeModel *loc_tree_create_and_fill_model(const gchar * fname)
         if (country)
             g_free(country);
 
-        /* Close IO chanel; don't care about status.
+        /* Close IO channel; don't care about status.
            Shutdown will flush the stream and close the channel
            as soon as the reference count is dropped. Order matters!
          */
@@ -413,13 +413,13 @@ static GtkTreeModel *loc_tree_create_and_fill_model(const gchar * fname)
     return GTK_TREE_MODEL(treestore);
 }
 
-/* render column containg float
+/* render column containing float
    by using this instead of the default data function, we can
    disable lat,lon and alt for the continent and country rows.
 
    Please note that this function only affects how the numbers are
    displayed (rendered), the tree_store will still contain the
-   original flaoting point numbers. Very cool!
+   original floating point numbers. Very cool!
 */
 static void loc_tree_float_cell_data_function(GtkTreeViewColumn * col,
                                               GtkCellRenderer * renderer,

--- a/src/locator.c
+++ b/src/locator.c
@@ -279,7 +279,7 @@ int dec2dms (double dec, int *degrees, int *minutes, double *seconds, int *sw) {
  *  notation common on many GPS units.
  *
  *  When passed a value < -180 or > 180, the value will be normalized
- *  within these limits and the sign set apropriately.
+ *  within these limits and the sign set appropriately.
  *
  *  Upon return dec2dmmm guarantees 0 >= \a degrees <= 180,
  *  0.0 >= \a minutes < 60.0.

--- a/src/main.c
+++ b/src/main.c
@@ -69,7 +69,7 @@ static gboolean tle_upd_running = FALSE;
 static gboolean tle_upd_note_sent = FALSE;
 
 
-/* private funtion prototypes */
+/* private function prototypes */
 static void     gpredict_app_create(void);
 static gint     gpredict_app_delete(GtkWidget *, GdkEvent *, gpointer);
 static void     gpredict_app_destroy(GtkWidget *, gpointer);
@@ -223,7 +223,7 @@ static void gpredict_app_create()
     title = g_strdup(_("Gpredict"));
     icon = logo_file_name("gpredict_icon_color.svg");
 
-    /* ceate window, add title and icon, restore size and position */
+    /* create window, add title and icon, restore size and position */
     app = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 
     gtk_window_set_title(GTK_WINDOW(app), title);
@@ -290,7 +290,7 @@ static void gpredict_sig_handler(int sig)
  * This function handles the delete event received by the main application
  * window (eg. when the window is closed by the WM). This function simply
  * returns FALSE indicating that the main application window should be
- * destroyed by emiting the destroy signal.
+ * destroyed by emitting the destroy signal.
  *
  */
 static gint gpredict_app_delete(GtkWidget * widget, GdkEvent * event,

--- a/src/mod-cfg.c
+++ b/src/mod-cfg.c
@@ -460,7 +460,7 @@ static gint compare_func(GtkTreeModel * model,
  *
  * @param view Pointer to the GtkTreeView object.
  * @param path The path of the row that was activated.
- * @param column The column where the activation occured.
+ * @param column The column where the activation occurred.
  * @param data Pointer to the GtkSatselector widget.
  *
  * This function is called when the user double clicks on a satellite in the

--- a/src/orbit-tools.c
+++ b/src/orbit-tools.c
@@ -67,7 +67,7 @@ get_orbit_type (sat_t *sat)
  *
  *     fabs (sat.meanmotion - 1.0027) < 0.0002
  *
- * Note: Appearantly, the mean motion can deviate much more from 1.0027 than 0.0002
+ * Note: Apparently, the mean motion can deviate much more from 1.0027 than 0.0002
  */
 gboolean
 geostationary  (sat_t *sat)

--- a/src/qth-data.c
+++ b/src/qth-data.c
@@ -589,7 +589,7 @@ gboolean qth_data_update(qth_t * qth, gdouble t)
 }
 
 /**
- * Initialize whatever structures inside the qth_t stucture for later updates.
+ * Initialize whatever structures inside the qth_t structure for later updates.
  *
  * \param qth the qth data structure to update
  * 
@@ -698,7 +698,7 @@ gboolean qth_data_update_init(qth_t * qth)
 }
 
 /**
- * Shutdown and free structures inside the qth_t stucture were used for updates.
+ * Shutdown and free structures inside the qth_t structure were used for updates.
  *
  * \param qth the qth data structure to update
  * 
@@ -797,7 +797,7 @@ void qth_small_save(qth_t * qth, qth_small_t * qth_small)
 }
 
 /**
- * Validate the contents of a qth structure and correct if neccessary
+ * Validate the contents of a qth structure and correct if necessary
  *
  * \param qth the qth data structure to cleanup
  */

--- a/src/qth-editor.c
+++ b/src/qth-editor.c
@@ -695,7 +695,7 @@ GtkResponseType qth_editor_run(qth_t * qth, GtkWindow * parent)
     gint            response;
     gboolean        finished = FALSE;
 
-    /* crate dialog and add contents */
+    /* create dialog and add contents */
     dialog = gtk_dialog_new_with_buttons(_("Edit ground station data"),
                                          parent,
                                          GTK_DIALOG_MODAL |
@@ -728,7 +728,7 @@ GtkResponseType qth_editor_run(qth_t * qth, GtkWindow * parent)
             }
             else
             {
-                /* and error occured; try again */
+                /* and error occurred; try again */
                 GtkWidget      *errd;
 
                 errd = gtk_message_dialog_new(parent,

--- a/src/sat-cfg.c
+++ b/src/sat-cfg.c
@@ -90,21 +90,21 @@
 
 /** Structure representing a boolean value */
 typedef struct {
-    gchar          *group;      /*!< The configration group */
+    gchar          *group;      /*!< The configuration group */
     gchar          *key;        /*!< The configuration key */
     gboolean        defval;     /*!< The default value */
 } sat_cfg_bool_t;
 
 /** Structure representing an integer value */
 typedef struct {
-    gchar          *group;      /*!< The configration group */
+    gchar          *group;      /*!< The configuration group */
     gchar          *key;        /*!< The configuration key */
     gint            defval;     /*!< The default value */
 } sat_cfg_int_t;
 
 /** Structure representing a string value */
 typedef struct {
-    gchar          *group;      /*!< The configration group */
+    gchar          *group;      /*!< The configuration group */
     gchar          *key;        /*!< The configuration key */
     gchar          *defval;     /*!< The default value */
 } sat_cfg_str_t;
@@ -348,7 +348,7 @@ guint sat_cfg_load()
 
 /**
  * Save configuration data.
- * @return 0 on success, 1 if an error occured.
+ * @return 0 on success, 1 if an error occurred.
  *
  * This function saves the configuration data currently stored in
  * memory to the gpredict.cfg file.

--- a/src/sat-log-browser.c
+++ b/src/sat-log-browser.c
@@ -187,7 +187,7 @@ static int read_debug_file(const gchar * filename)
 
             errorcode = 0;
 
-            /* Close IO chanel; don't care about status.
+            /* Close IO channel; don't care about status.
                Shutdown will flush the stream and close the channel
                as soon as the reference count is dropped. Order matters!
              */
@@ -197,7 +197,7 @@ static int read_debug_file(const gchar * filename)
         }
         else
         {
-            /* an error occured */
+            /* an error occurred */
             sat_log_log(SAT_LOG_LEVEL_ERROR,
                         _("%s:%d: Error open debug log (%s)"),
                         __FILE__, __LINE__, error->message);
@@ -363,7 +363,7 @@ static GtkWidget *create_message_summary()
     gtk_frame_set_label_align(GTK_FRAME(frame), 0.5, 0.5);
     gtk_container_add(GTK_CONTAINER(frame), table);
 
-    /* pack frame into vbox so that it doesn't gets streched vertically */
+    /* pack frame into vbox so that it doesn't gets stretched vertically */
     vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     gtk_box_pack_start(GTK_BOX(vbox), frame, FALSE, FALSE, 0);
 

--- a/src/sat-pass-dialogs.c
+++ b/src/sat-pass-dialogs.c
@@ -628,14 +628,14 @@ static void check_and_set_single_cell_renderer(GtkTreeViewColumn * column,
     }
 }
 
-/* render column containg lat/lon
+/* render column containing lat/lon
    by using this instead of the default data function, we can
    control the number of decimals and display the coordinates in a
    fancy way, including degree sign and NWSE suffixes.
 
    Please note that this function only affects how the numbers are
    displayed (rendered), the tree_store will still contain the
-   original flaoting point numbers. Very cool!
+   original floating point numbers. Very cool!
 */
 static void latlon_cell_data_function(GtkTreeViewColumn * col,
                                       GtkCellRenderer * renderer,
@@ -1320,7 +1320,7 @@ static void view_popup_menu(GtkWidget * treeview, GdkEventButton * event,
  *
  * @param view Pointer to the GtkTreeView object.
  * @param path The path of the row that was activated.
- * @param column The column where the activation occured.
+ * @param column The column where the activation occurred.
  * @param data Pointer to the toplevel window.
  *
  * This function is called when the user double clicks on a pass in the

--- a/src/sat-pref-general.c
+++ b/src/sat-pref-general.c
@@ -39,7 +39,7 @@
  *
  * The widgets must be preloaded with values from config. If a config value
  * is NULL, sensible default values, eg. those from defaults.h should
- * be laoded.
+ * be loaded.
  */
 GtkWidget      *sat_pref_general_create()
 {

--- a/src/sat-pref-interfaces.c
+++ b/src/sat-pref-interfaces.c
@@ -40,7 +40,7 @@
  *
  * The widgets must be preloaded with values from config. If a config value
  * is NULL, sensible default values, eg. those from defaults.h should
- * be laoded.
+ * be loaded.
  */
 GtkWidget      *sat_pref_interfaces_create()
 {

--- a/src/sat-pref-map-view.c
+++ b/src/sat-pref-map-view.c
@@ -1368,7 +1368,7 @@ static void create_reset_button(GKeyFile * cfg, GtkBox * vbox)
  *
  * The widgets must be preloaded with values from config. If a config value
  * is NULL, sensible default values, eg. those from defaults.h should
- * be laoded.
+ * be loaded.
  */
 GtkWidget      *sat_pref_map_view_create(GKeyFile * cfg)
 {

--- a/src/sat-pref-modules.c
+++ b/src/sat-pref-modules.c
@@ -45,7 +45,7 @@
  *
  * The widgets must be preloaded with values from config. If a config value
  * is NULL, sensible default values, eg. those from defaults.h should
- * be laoded.
+ * be loaded.
  *
  * @note The "modules" tab is different from the others in that it is used
  *       by both the saf-pref dialog to edit global settings and the mod-cfg

--- a/src/sat-pref-polar-view.c
+++ b/src/sat-pref-polar-view.c
@@ -988,7 +988,7 @@ void sat_pref_polar_view_ok(GKeyFile * cfg)
  *
  * The widgets must be preloaded with values from config. If a config value
  * is NULL, sensible default values, eg. those from defaults.h should
- * be laoded.
+ * be loaded.
  */
 GtkWidget      *sat_pref_polar_view_create(GKeyFile * cfg)
 {

--- a/src/sat-pref-predict.c
+++ b/src/sat-pref-predict.c
@@ -43,7 +43,7 @@
  *
  * The widgets must be preloaded with values from config. If a config value
  * is NULL, sensible default values, eg. those from defaults.h should
- * be laoded.
+ * be loaded.
  */
 GtkWidget      *sat_pref_predict_create()
 {

--- a/src/sat-pref-qth-editor.c
+++ b/src/sat-pref-qth-editor.c
@@ -803,7 +803,7 @@ void sat_pref_qth_editor_run(GtkTreeView * treeview, gboolean new)
     gint            response;
     gboolean        finished = FALSE;
 
-    /* crate dialog and add contents */
+    /* create dialog and add contents */
     dialog = gtk_dialog_new_with_buttons(_("Edit ground station data"),
                                          GTK_WINDOW(window),
                                          GTK_DIALOG_MODAL |

--- a/src/sat-pref-qth.c
+++ b/src/sat-pref-qth.c
@@ -281,7 +281,7 @@ static GtkWidget *create_qth_list()
  *
  * This function creates the data storage necessary for the
  * list view. The newly created tree model is populated with
- * data from the .qth files in the users config diretory.
+ * data from the .qth files in the users config directory.
  * The individual .qth files are read by the read_qth_file
  * function.
  */
@@ -741,14 +741,14 @@ static gboolean clear_default_flags(GtkTreeModel * model, GtkTreePath * path,
     return FALSE;
 }
 
-/* render column containg float
+/* render column containing float
    by using this instead of the default data function, we can
    control the number of decimals and display the coordinates in a
    fancy way, including degree sign and NWSE suffixes.
 
    Please note that this function only affects how the numbers are
    displayed (rendered), the tree_store will still contain the
-   original flaoting point numbers. Very cool!
+   original floating point numbers. Very cool!
 */
 static void float_cell_data_function(GtkTreeViewColumn * col,
                                      GtkCellRenderer * renderer,

--- a/src/sat-pref-rig-editor.c
+++ b/src/sat-pref-rig-editor.c
@@ -520,7 +520,7 @@ void sat_pref_rig_editor_run(radio_conf_t * conf)
     gint            response;
     gboolean        finished = FALSE;
 
-    /* crate dialog and add contents */
+    /* create dialog and add contents */
     dialog = gtk_dialog_new_with_buttons(_("Edit radio configuration"),
                                          GTK_WINDOW(window),
                                          GTK_DIALOG_MODAL |

--- a/src/sat-pref-rot-editor.c
+++ b/src/sat-pref-rot-editor.c
@@ -345,7 +345,7 @@ void sat_pref_rot_editor_run(rotor_conf_t * conf)
     gint            response;
     gboolean        finished = FALSE;
 
-    /* crate dialog and add contents */
+    /* create dialog and add contents */
     dialog = gtk_dialog_new_with_buttons(_("Edit rotator configuration"),
                                          GTK_WINDOW(window),
                                          GTK_DIALOG_MODAL |

--- a/src/sat-pref-sky-at-glance.c
+++ b/src/sat-pref-sky-at-glance.c
@@ -128,7 +128,7 @@ static void spin_changed_cb(GtkWidget * spinner, gpointer data)
  *
  * This function is called when the user clicks on the RESET button. The function
  * will get the default values for the parameters and set the dirty and reset flags
- * apropriately. The reset will not have any effect if the user cancels the
+ * appropriately. The reset will not have any effect if the user cancels the
  * dialog.
  */
 static void reset_cb(GtkWidget * button, gpointer data)

--- a/src/sat-pref-tle.c
+++ b/src/sat-pref-tle.c
@@ -116,7 +116,7 @@ static void create_auto_update(GtkWidget * vbox)
     g_signal_connect(autom, "toggled", G_CALLBACK(value_changed_cb), NULL);
 }
 
-/* Calback function called when an URL entry in the list has been edited */
+/* Callback function called when an URL entry in the list has been edited */
 static void url_edited_cb(GtkCellRendererText * renderer, gchar * path,
                           gchar * new_text, GtkListStore * tle_store)
 {
@@ -346,7 +346,7 @@ static void create_misc(GtkWidget * vbox)
  *
  * This function is called when the user clicks on the RESET button. The function
  * will get the default values for the parameters and set the dirty and reset flags
- * apropriately. The reset will not have any effect if the user cancels the
+ * appropriately. The reset will not have any effect if the user cancels the
  * dialog.
  */
 static void reset_cb(GtkWidget * button, gpointer data)

--- a/src/sat-pref.c
+++ b/src/sat-pref.c
@@ -62,7 +62,7 @@ static void     button_press_cb(GtkWidget * widget, gpointer nbook);
  * could have the following sub-groups: General, List View, Map View and so on.
  * The tabs of the notebook are invisible, instead a vertical icon list
  * placed on the left of the notebook is used to navigate through the
- * notebook pages. The icon list is actually impemented using pixmap buttons
+ * notebook pages. The icon list is actually implemented using pixmap buttons
  * in a button box. Using something like the GtkIconView would have been better
  * but that seems to be rather useless when packed into a box.
  */

--- a/src/sat-vis.c
+++ b/src/sat-vis.c
@@ -49,7 +49,7 @@ static gchar *VIS2STR[SAT_VIS_NUM] = {
  *  \param sat The satellite structure.
  *  \param qth The QTH
  *  \param jul_utc The time at which the visibility should be calculated.
- *  \return The visiblity code.
+ *  \return The visibility code.
  *
  */
 sat_vis_t

--- a/src/sgpsdp/2_README
+++ b/src/sgpsdp/2_README
@@ -40,7 +40,7 @@ This package should contain the following files:
               calculating the observer-centered position of the sun.
 
 7. sgp_time.c: Functions needed to calculate and convert time in various 
-               formats, e.g. Julian, calender etc.
+               formats, e.g. Julian, calendar etc.
 
 8. solar.c: Functions for calculating the position of the sun.
 
@@ -155,7 +155,7 @@ NORAD Spacetrack report #3 is also included: http://celestrack.com/
 Change Log:
 ================
 
-Version 0.1: Was the first relased after local bug-fixing.
+Version 0.1: Was the first released after local bug-fixing.
 
 Version 0.2: Function Date_Time was re-written to include calculation
 of tm_wday and tm_isdst members in the struct tm type value it returns.

--- a/src/sgpsdp/sgp4sdp4.h
+++ b/src/sgpsdp/sgp4sdp4.h
@@ -80,7 +80,7 @@ typedef struct {
  * \bug It is uncertain whether the units are uniform across all functions.
  */
 typedef struct {
-    double          lat;        /*!< Lattitude [rad] */
+    double          lat;        /*!< Latitude [rad] */
     double          lon;        /*!< Longitude [rad] */
     double          alt;        /*!< Altitude [km]? */
     double          theta;

--- a/src/sgpsdp/sgp_in.c
+++ b/src/sgpsdp/sgp_in.c
@@ -46,7 +46,7 @@
 /* tle_set is a character string holding the two lines read    */
 /* from a text file containing NASA format Keplerian elements. */
 /* NOTE!!! The stuff about two lines is not quite true.
-   The function assumes that tle_set[0] is the begining
+   The function assumes that tle_set[0] is the beginning
    of the line and that there are 68 elements - see the consumer
 */
 int Checksum_Good(char *tle_set)
@@ -331,10 +331,10 @@ int Get_Next_Tle_Set(char line[3][80], tle_t * tle)
     return (1);
 }
 
-/* Selects the apropriate ephemeris type to be used */
+/* Selects the appropriate ephemeris type to be used */
 /* for predictions according to the data in the TLE */
 /* It also processes values in the tle set so that  */
-/* they are apropriate for the sgp4/sdp4 routines   */
+/* they are appropriate for the sgp4/sdp4 routines   */
 void select_ephemeris(sat_t * sat)
 {
     double          ao, xnodp, dd1, dd2, delo, temp, a1, del1, r1;

--- a/src/sgpsdp/sgp_math.c
+++ b/src/sgpsdp/sgp_math.c
@@ -203,7 +203,7 @@ int Round(double arg)
     return ((int)floor(arg + 0.5));
 }
 
-/* Returns the floor integer of a double arguement, as double */
+/* Returns the floor integer of a double argument, as double */
 double Int(double arg)
 {
     return (floor(arg));

--- a/src/tle-update.c
+++ b/src/tle-update.c
@@ -493,7 +493,7 @@ void tle_update_from_network(gboolean silent,
     const gchar    *fname;
     gchar          *text;
     GError         *err = NULL;
-    guint           success = 0;        /* no. of successfull downloads */
+    guint           success = 0;        /* no. of successful downloads */
 
     /* bail out if we are already in an update process */
     if (g_mutex_trylock(&tle_in_progress) == FALSE)
@@ -799,7 +799,7 @@ static gint read_fresh_tle(const gchar * dir, const gchar * fnam,
 
     /* 
        Normal cases to check
-       1. 3 line tle file as in amatuer.txt from celestrak
+       1. 3 line tle file as in amateur.txt from celestrak
        2. 2 line tle file as in .... from celestrak
 
        corner cases to check 
@@ -1266,7 +1266,7 @@ static void update_tle_in_file(const gchar * ldname,
 
             if (ntle->satname != NULL)
             {
-                /* when a satellite first appears in the elements it is sometimes refered to by the 
+                /* when a satellite first appears in the elements it is sometimes referred to by the 
                    international designator which is awkward after it is given a name */
                 if (!is_computer_generated_name(ntle->satname))
                 {

--- a/src/trsp-update.c
+++ b/src/trsp-update.c
@@ -403,7 +403,7 @@ void modes_update_from_network()
     CURLcode        res;
 #endif
     FILE           *outfile;
-    guint           success = 0;        /* no. of successfull downloads */
+    guint           success = 0;        /* no. of successful downloads */
 
     server = sat_cfg_get_str(SAT_CFG_STR_TRSP_SERVER);
     proxy = sat_cfg_get_str(SAT_CFG_STR_TRSP_PROXY);
@@ -540,7 +540,7 @@ void trsp_update_from_network(gboolean silent,
     gchar          *cache;
     gchar          *text;
 
-    guint           success = 0;        /* no. of successfull downloads */
+    guint           success = 0;        /* no. of successful downloads */
 
     (void)label2;
 

--- a/win32/README
+++ b/win32/README
@@ -9,7 +9,7 @@ Install MSYS2, open a shell and install the Gtk3 and Goocanvas2 packages,
 following the instructions from GTK team:
 https://www.gtk.org/download/windows.php
 
-Once your MSYS2 output folder (/mingw32 or simlar) is accessible from
+Once your MSYS2 output folder (/mingw32 or similar) is accessible from
 this system, adjust the MINGW_ROOT parameter in config.mk to suit.
 
 You should now be able to cross-compile the Win32 version of GPredict
@@ -20,7 +20,7 @@ https://github.com/csete/gpredict/issues/110
 
 
 To build a deployable ZIP archive, use 'make dist', which packages all
-binary DLLs from dependant packages along with gpredict[-con].exe into
+binary DLLs from dependent packages along with gpredict[-con].exe into
 a versioned ZIP.
 
 Good luck!


### PR DESCRIPTION
This PR fixes spelling errors in Doxygen comments and in plain comments.
There are no changes in user-visible strings.

Fixed with:
codespell --skip data,po --ignore-words-list=te --summary --write-changes

```
SUMMARY:
alway         3
amatuer       1
appearantly   2
apropriate    3
apropriately  3
arguement     1
asociated     3
becasue       2
begining      1
calback       1
calender      1
ceate         2
chanel        3
conencted     1
configration  3
containg      5
crate         4
dependant     1
diretory      1
emiting       1
exisits       1
flaoting      4
funcion       2
funtion       1
higer         2
imediately    1
impemented    1
laoded        6
lattitude     1
layed         1
mising        1
neccessary    1
numer         3
occured       8
refered       1
referene      3
relased       1
satelite      1
similiarly    1
simlar        1
simpley       1
som           2
streched      1
stucture      2
substract     1
successfull   4
supprot       1
therfore      1
useable       2
visiblity     1
wile          1
wont          1
```