### PR TITLE
Added a new mode for radios that utilize SATMODE in Hamlib for cross …

### DIFF
--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -1489,6 +1489,21 @@ static inline gboolean check_get_response(gchar * buffback, gboolean retcode,
     return retcode;
 }
 
+/* Setup VFOs for satellite operation (simplex or duplex) */
+static gboolean setup_satmode(GtkRigCtrl * ctrl)
+{
+    gchar          *buff;
+    gchar           buffback[256];
+    gboolean        retcode;
+
+    buff = g_strdup("U SATMODE 1\x0a");
+
+    retcode = send_rigctld_command(ctrl, ctrl->sock, buff, buffback, 128);
+    g_free(buff);
+
+    return (check_set_response(buffback, retcode, __func__));
+}
+
 /* Setup VFOs for split operation (simplex or duplex) */
 static gboolean setup_split(GtkRigCtrl * ctrl)
 {
@@ -2755,8 +2770,14 @@ static void rigctrl_open(GtkRigCtrl * data)
             break;
 
         case RIG_TYPE_DUPLEX:
-            /* set rig into SAT mode (hamlib needs it even if rig already in SAT) */
+            /* set rig into Split mode (hamlib needs it even if rig already in Split) */
             setup_split(ctrl);
+            exec_duplex_cycle(ctrl);
+            break;
+
+        case RIG_TYPE_SAT:
+            /* set rig into SAT mode (hamlib needs it even if rig already in SAT) */
+            setup_satmode(ctrl);
             exec_duplex_cycle(ctrl);
             break;
 
@@ -2844,6 +2865,10 @@ gpointer rigctl_run(gpointer data)
                 break;
 
             case RIG_TYPE_DUPLEX:
+                exec_duplex_cycle(t_ctrl);
+                break;
+
+            case RIG_TYPE_SAT:
                 exec_duplex_cycle(t_ctrl);
                 break;
 

--- a/src/radio-conf.h
+++ b/src/radio-conf.h
@@ -39,7 +39,8 @@ typedef enum {
     RIG_TYPE_TRX,               /*!< Rig can be used as RX/TX (half-duplex only) */
     RIG_TYPE_DUPLEX,            /*!< Rig is a full duplex radio, e.g. IC910 */
     RIG_TYPE_TOGGLE_AUTO,       /*!< Special mode for FT-817, 857 and 897 using auto T/R switch */
-    RIG_TYPE_TOGGLE_MAN         /*!< Special mode for FT-817, 857 and 897 using manual T/R switch */
+    RIG_TYPE_TOGGLE_MAN,        /*!< Special mode for FT-817, 857 and 897 using manual T/R switch */
+    RIG_TYPE_SAT                /*!< Rig is a full duplex radio that has a SAT mode, e.g. IC9700 */
 } rig_type_t;
 
 typedef enum {

--- a/src/sat-pref-rig-editor.c
+++ b/src/sat-pref-rig-editor.c
@@ -82,7 +82,7 @@ static void update_widgets(radio_conf_t * conf)
     gtk_combo_box_set_active(GTK_COMBO_BOX(ptt), conf->ptt);
 
     /* vfo up/down */
-    if (conf->type == RIG_TYPE_DUPLEX)
+    if ((conf->type == RIG_TYPE_DUPLEX) || (conf->type == RIG_TYPE_SAT))
     {
         if (conf->vfoUp == VFO_MAIN)
             gtk_combo_box_set_active(GTK_COMBO_BOX(vfo), 1);
@@ -116,7 +116,8 @@ static void vfo_changed(GtkWidget * widget, gpointer data)
     (void)data;
 
     if (gtk_combo_box_get_active(GTK_COMBO_BOX(widget)) == 0 &&
-        gtk_combo_box_get_active(GTK_COMBO_BOX(type)) == RIG_TYPE_DUPLEX)
+            ((gtk_combo_box_get_active(GTK_COMBO_BOX(type)) == RIG_TYPE_DUPLEX) ||
+                    gtk_combo_box_get_active(GTK_COMBO_BOX(type)) == RIG_TYPE_SAT))
     {
         /* not good, we need to have proper VFO combi for this type */
         gtk_combo_box_set_active(GTK_COMBO_BOX(widget), 1);
@@ -218,7 +219,8 @@ static void type_changed(GtkWidget * widget, gpointer data)
 
 
     /* VFO consistency */
-    if (gtk_combo_box_get_active(GTK_COMBO_BOX(widget)) == RIG_TYPE_DUPLEX &&
+    if (((gtk_combo_box_get_active(GTK_COMBO_BOX(type)) == RIG_TYPE_DUPLEX) ||
+         gtk_combo_box_get_active(GTK_COMBO_BOX(type)) == RIG_TYPE_SAT) &&
         gtk_combo_box_get_active(GTK_COMBO_BOX(vfo)) == 0)
     {
         gtk_combo_box_set_active(GTK_COMBO_BOX(vfo), 1);
@@ -296,6 +298,7 @@ static GtkWidget *create_editor_widgets(radio_conf_t * conf)
                                    _("FT817/857/897 (auto)"));
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(type),
                                    _("FT817/857/897 (manual)"));
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(type), _("Full-duplex SAT mode"));
     gtk_combo_box_set_active(GTK_COMBO_BOX(type), RIG_TYPE_RX);
     g_signal_connect(type, "changed", G_CALLBACK(type_changed), NULL);
     gtk_widget_set_tooltip_markup(type,
@@ -333,7 +336,12 @@ static GtkWidget *create_editor_widgets(radio_conf_t * conf)
                                     " that switching to TX is done by pressing the"
                                     " SPACE key on the keyboard. Gpredict will "
                                     "then update the TX Doppler before actually"
-                                    " switching to TX."));
+                                    " switching to TX."
+                                    "<b>Full-duplex SAT mode:</b>  The radio is a full-duplex"
+                                    " radio which has a dedicated satellite mode, such "
+                                    "as the IC9700. Gpredict will be continuously tuning both "
+                                    "uplink and downlink simultaneously and not care about "
+                                    "PTT setting.\n\n"));
     gtk_grid_attach(GTK_GRID(table), type, 1, 3, 2, 1);
 
     /* ptt */
@@ -475,7 +483,7 @@ static gboolean apply_changes(radio_conf_t * conf)
     conf->ptt = gtk_combo_box_get_active(GTK_COMBO_BOX(ptt));
 
     /* vfo up/down */
-    if (conf->type == RIG_TYPE_DUPLEX)
+    if ((conf->type == RIG_TYPE_DUPLEX) || conf->type == RIG_TYPE_SAT)
     {
         switch (gtk_combo_box_get_active(GTK_COMBO_BOX(vfo)))
         {

--- a/src/sat-pref-rig.c
+++ b/src/sat-pref-rig.c
@@ -218,6 +218,10 @@ static void render_type(GtkTreeViewColumn * col,
         g_object_set(renderer, "text", _("FT817/857/897 (man)"), NULL);
         break;
 
+    case RIG_TYPE_SAT:
+        g_object_set(renderer, "text", _("IC9700 (SAT mode)"), NULL);
+        break;
+
     default:
         g_object_set(renderer, "text", _("ERROR"), NULL);
         break;


### PR DESCRIPTION
…band split. 
        Some users of Hamlib have had to remain on Hamlib 4.0 because using later versions would cause GPredict to disconnect from our IC-9700s after a few cycles. I found that somewhere around Hamlib V4.1, the way that some radios use split was changed.  Radios like the IC-9700 have two split modes, standard split and satellite mode. Standard split, achieved with "S 1 (main VFO)" is for single band split. Think working a DX station who is listening a few KHz off of their transmit frequency. Satellite mode is for the cross band split we use on satellites. Originally, Hamlib only supported satellite mode on radios like the IC-9700, which is why "S 1 (main VFO)" used to work. Now, "S 1 (main VFO)" will put the IC-9700 into standard split, which is causing GPredict to disconnect from the radio. Satellite mode (SATMODE as it is referred to in Hamlib) on the IC-9700 now has to be activated by using "U SATMODE 1"
        
While I know the change to Hamlib has broken GPredict compatibility for the IC-9700 (see #287,) I cannot be sure that it has been changed for every radio in Hamlib. To account for this, I have chosen to add a new radio type, Full-duplex SAT mode. Full-duplex SAT mode uses the new SATMODE Hamlib mode for split and has allowed for me to use my IC-9700 with GPredict again. The way the existing Full-Duplex radio type works has not been changed to ensure I have not broken compatibility with other radios.

Please let me know if you have any questions or concerns.