### PR TITLE
Fix gcc fortify warnings

### DIFF
--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -2304,7 +2304,7 @@ static gboolean get_ptt(GtkRigCtrl * ctrl, gint sock)
     {
         /* send command get_ptt (t) */
         if (ctrl->conf->vfo_opt)
-            buff = g_strdup_printf("t vfoCurr\x0a");
+            buff = g_strdup_printf("t currVFO\x0a");
         else
             buff = g_strdup_printf("t\x0a");
     }
@@ -2312,7 +2312,7 @@ static gboolean get_ptt(GtkRigCtrl * ctrl, gint sock)
     {
         /* send command \get_dcd */
         if (ctrl->conf->vfo_opt)
-            buff = g_strdup_printf("%c vfoCurr\x0a", 0x8b);
+            buff = g_strdup_printf("%c currVFO\x0a", 0x8b);
         else
             buff = g_strdup_printf("%c\x0a", 0x8b);
     }
@@ -2341,14 +2341,14 @@ static gboolean set_ptt(GtkRigCtrl * ctrl, gint sock, gboolean ptt)
     if (ptt == TRUE) 
     {
         if (ctrl->conf->vfo_opt)
-            buff = g_strdup_printf("T vfoCurr 1\x0aq\x0a");
+            buff = g_strdup_printf("T currVFO 1\x0aq\x0a");
         else
             buff = g_strdup_printf("T 1\x0aq\x0a");
     }
     else
     {
         if (ctrl->conf->vfo_opt)
-            buff = g_strdup_printf("T vfoCurr 0\x0aq\x0a");
+            buff = g_strdup_printf("T currVFO 0\x0aq\x0a");
         else
             buff = g_strdup_printf("T 0\x0aq\x0a");
     }

--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -717,7 +717,7 @@ static void trsp_tune_cb(GtkButton * button, gpointer data)
     if ((ctrl->trsp->downlow > 0) && (ctrl->trsp->downhigh > 0))
     {
         freq = ctrl->trsp->downlow +
-            abs(ctrl->trsp->downhigh - ctrl->trsp->downlow) / 2;
+            labs(ctrl->trsp->downhigh - ctrl->trsp->downlow) / 2;
         gtk_freq_knob_set_value(GTK_FREQ_KNOB(ctrl->SatFreqDown), freq);
 
         /* invalidate RIG<->GPREDICT sync */
@@ -728,7 +728,7 @@ static void trsp_tune_cb(GtkButton * button, gpointer data)
     if ((ctrl->trsp->uplow > 0) && (ctrl->trsp->uphigh > 0))
     {
         freq = ctrl->trsp->uplow +
-            abs(ctrl->trsp->uphigh - ctrl->trsp->uplow) / 2;
+            labs(ctrl->trsp->uphigh - ctrl->trsp->uplow) / 2;
         gtk_freq_knob_set_value(GTK_FREQ_KNOB(ctrl->SatFreqUp), freq);
 
         /* invalidate RIG<->GPREDICT sync */

--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -717,7 +717,7 @@ static void trsp_tune_cb(GtkButton * button, gpointer data)
     if ((ctrl->trsp->downlow > 0) && (ctrl->trsp->downhigh > 0))
     {
         freq = ctrl->trsp->downlow +
-            labs(ctrl->trsp->downhigh - ctrl->trsp->downlow) / 2;
+            labs((long)ctrl->trsp->downhigh - (long)ctrl->trsp->downlow) / 2;
         gtk_freq_knob_set_value(GTK_FREQ_KNOB(ctrl->SatFreqDown), freq);
 
         /* invalidate RIG<->GPREDICT sync */
@@ -728,7 +728,7 @@ static void trsp_tune_cb(GtkButton * button, gpointer data)
     if ((ctrl->trsp->uplow > 0) && (ctrl->trsp->uphigh > 0))
     {
         freq = ctrl->trsp->uplow +
-            labs(ctrl->trsp->uphigh - ctrl->trsp->uplow) / 2;
+            labs((long)ctrl->trsp->uphigh - (long)ctrl->trsp->uplow) / 2;
         gtk_freq_knob_set_value(GTK_FREQ_KNOB(ctrl->SatFreqUp), freq);
 
         /* invalidate RIG<->GPREDICT sync */

--- a/src/radio-conf.h
+++ b/src/radio-conf.h
@@ -72,6 +72,8 @@ typedef struct {
 
     gboolean        signal_aos; /*!< Send AOS notification to RIG */
     gboolean        signal_los; /*!< Send LOS notification to RIG */
+
+    gint            vfo_opt;    /*!< Keep track of vfo_opt being enabled in rigctld */
 } radio_conf_t;
 
 

--- a/src/tle-update.c
+++ b/src/tle-update.c
@@ -907,7 +907,7 @@ static gint read_fresh_tle(const gchar * dir, const gchar * fnam,
             case 1:
                 strncpy(tle_working[0], tle_working[1], 80);
                 strncpy(tle_working[1], tle_working[2], 80);
-                strncpy(tle_working[2], linetmp, 80);
+                memcpy(tle_working[2], linetmp, 80);
                 tle_working[2][79] = 0;         // make coverity happy
                 break;
             default:
@@ -965,10 +965,10 @@ static gint read_fresh_tle(const gchar * dir, const gchar * fnam,
                 /* put in a dummy name of form yyyy-nnaa base on international id */
                 /* this special form will be overwritten if a three line tle ever has another name */
 
-                strncpy(idstr, &tle_working[0][11], 6);
+                memcpy(idstr, &tle_working[0][11], 6);
                 g_strstrip(idstr);
-                strncpy(idyearstr, &tle_working[0][9], 2);
-                idstr[6] = '\0';
+                memcpy(idyearstr, &tle_working[0][9], 2);
+                idstr[6] = 0;
                 idyearstr[2] = '\0';
                 idyear = g_ascii_strtod(idyearstr, NULL);
 


### PR DESCRIPTION
strncpy can produce "truncated" warnings and can be easily replaced by memcpy and ensuring the string is null terminated.
