### PR TITLE
Add support for VFO mode in Rigctrl. Gpredict will now try to enable …

### DIFF
--- a/src/gtk-rig-ctrl.h
+++ b/src/gtk-rig-ctrl.h
@@ -55,6 +55,7 @@ struct _gtk_rig_ctrl {
     GSList         *trsplist;   /*!< List of available transponders */
     trsp_t         *trsp;       /*!< Pointer to the current transponder configuration */
     gboolean        trsplock;   /*!< Flag indicating whether uplink and downlink are lockled */
+    gboolean        vfo_opt_supported; /*!< Does the rig support and have the --vfo enabled in Hamlib*/
 
     GSList         *sats;       /*!< List of sats in parent module */
     sat_t          *target;     /*!< Target satellite */

--- a/src/radio-conf.c
+++ b/src/radio-conf.c
@@ -199,9 +199,10 @@ gboolean radio_conf_read(radio_conf_t * conf)
         return FALSE;
     }
 
-    /* VFO up and down, only if radio is full-duplex */
-    if (conf->type == RIG_TYPE_DUPLEX)
-    {
+    /* VFO up and down, only if radio is full-duplex, auto, manual */
+    if ((conf->type == RIG_TYPE_DUPLEX) ||
+        (conf->type == RIG_TYPE_TOGGLE_AUTO) ||
+        (conf->type == RIG_TYPE_TOGGLE_MAN)) {
         /* downlink */
         if (g_key_file_has_key(cfg, GROUP, KEY_VFO_DOWN, NULL))
         {
@@ -280,8 +281,9 @@ void radio_conf_save(radio_conf_t * conf)
     else
         g_key_file_set_integer(cfg, GROUP, KEY_CYCLE, conf->cycle);
 
-    if (conf->type == RIG_TYPE_DUPLEX)
-    {
+    if ((conf->type == RIG_TYPE_DUPLEX) ||
+        (conf->type == RIG_TYPE_TOGGLE_AUTO) ||
+        (conf->type == RIG_TYPE_TOGGLE_MAN)) {
         g_key_file_set_integer(cfg, GROUP, KEY_VFO_UP, conf->vfoUp);
         g_key_file_set_integer(cfg, GROUP, KEY_VFO_DOWN, conf->vfoDown);
     }

--- a/src/sat-pref-rig-editor.c
+++ b/src/sat-pref-rig-editor.c
@@ -82,17 +82,25 @@ static void update_widgets(radio_conf_t * conf)
     gtk_combo_box_set_active(GTK_COMBO_BOX(ptt), conf->ptt);
 
     /* vfo up/down */
-    if (conf->type == RIG_TYPE_DUPLEX)
-    {
-        if (conf->vfoUp == VFO_MAIN)
-            gtk_combo_box_set_active(GTK_COMBO_BOX(vfo), 1);
-        else if (conf->vfoUp == VFO_SUB)
-            gtk_combo_box_set_active(GTK_COMBO_BOX(vfo), 2);
-        else if (conf->vfoUp == VFO_A)
-            gtk_combo_box_set_active(GTK_COMBO_BOX(vfo), 3);
-        else
-            gtk_combo_box_set_active(GTK_COMBO_BOX(vfo), 4);
+    guint activeVfoSelection = 0;
+    if (((conf->type == RIG_TYPE_DUPLEX) ||
+         (conf->type == RIG_TYPE_TOGGLE_AUTO) ||
+         (conf->type == RIG_TYPE_TOGGLE_MAN))) {
+        switch (conf->type) {
+            case VFO_MAIN:
+                activeVfoSelection = 1;
+                break;
+            case VFO_SUB:
+                activeVfoSelection = 2;
+                break;
+            case VFO_A:
+                activeVfoSelection = 3;
+                break;
+            default:
+                activeVfoSelection = 4;
+        }
     }
+    gtk_combo_box_set_active(GTK_COMBO_BOX(vfo), activeVfoSelection);
 
     /* lo down in MHz */
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(lo), conf->lo / 1000000.0);
@@ -317,8 +325,8 @@ static GtkWidget *create_editor_widgets(radio_conf_t * conf)
                                     "gpredict cannot know whether to tune the "
                                     "RX or the TX).\n\n"
                                     "<b>Full-duplex:</b>  The radio is a full-duplex"
-                                    " radio, such as the IC910H. Gpredict will "
-                                    "be continuously tuning both uplink and "
+                                    " radio, such as the IC910H or IC-9700. Gpredict "
+                                    "will be continuously tuning both uplink and "
                                     "downlink simultaneously and not care about "
                                     "PTT setting.\n\n"
                                     "<b>FT817/857/897 (auto):</b> "
@@ -378,10 +386,11 @@ static GtkWidget *create_editor_widgets(radio_conf_t * conf)
     gtk_widget_set_tooltip_markup(vfo,
                                   _
                                   ("Select which VFO to use for uplink and downlink. "
-                                   "This setting is used for full-duplex radios only, "
+                                   "This setting is used for full-duplex, auto, and manual radios only, "
                                    "such as the IC-910H, FT-847 and the TS-2000.\n\n"
                                    "<b>IC-910H:</b> MAIN\342\206\221 / SUB\342\206\223\n"
                                    "<b>FT-847:</b> SUB\342\206\221 / MAIN\342\206\223\n"
+                                   "<b>IC-9700:</b> SUB\342\206\221 / MAIN\342\206\223\n"
                                    "<b>TS-2000:</b> B\342\206\221 / A\342\206\223"));
     gtk_grid_attach(GTK_GRID(table), vfo, 1, 5, 2, 1);
 
@@ -475,8 +484,9 @@ static gboolean apply_changes(radio_conf_t * conf)
     conf->ptt = gtk_combo_box_get_active(GTK_COMBO_BOX(ptt));
 
     /* vfo up/down */
-    if (conf->type == RIG_TYPE_DUPLEX)
-    {
+    if ((conf->type == RIG_TYPE_DUPLEX) ||
+        (conf->type == RIG_TYPE_TOGGLE_AUTO) ||
+        (conf->type == RIG_TYPE_TOGGLE_MAN)) {
         switch (gtk_combo_box_get_active(GTK_COMBO_BOX(vfo)))
         {
 


### PR DESCRIPTION
…and use VFO mode, usually set via the --vfo command line flag in Rigctrl, when connecting to a radio. If VFO mode could not be enabled, the old style of commanding the radio is used.

### Why is this needed:
@mdblack98 has indicated that Gpredict should move to default to VFO mode. 

### Changes that impact the users
- Users will now have to define the VFOs for the manual and auto modes, just like users of the full-duplex mode.

### Testing:
All radio modes (full duplex, RX only, ect) were tested on an FT-736R, IC-9700, FT-991A. Additionally, I have been using this version of Gpredict for my personal use for ~1 week. I have not encountered any issues.

### Testing results:
**FT-991A:**
- All modes working as intended. Testing with VFO mode forcefully disabled resulted in all modes working as intended.

**IC-9700:**
- All modes working as intended. Testing with VFO mode forcefully disabled resulted in all modes working as intended.

**FT-736R:**

- Testing could not be completed due to an issue with VFO mode breaking compatibility with this radio's split mode. PR to correct will be needed on the Hamlib repo. RX Only and TX Only modes were confirmed to be working as intended. Testing with VFO mode forcefully disabled resulted in all modes working as intended.

Additional relevant testing data will be provided on request.