### PR TITLE
Add a filter for satellites in Rotator Control

### DIFF
--- a/src/gtk-rot-ctrl.c
+++ b/src/gtk-rot-ctrl.c
@@ -28,7 +28,6 @@
  * 
  */
 
-#include "sgpsdp/sgp4sdp4.h"
 #ifdef HAVE_CONFIG_H
 #include <build-config.h>
 #endif

--- a/src/gtk-rot-ctrl.h
+++ b/src/gtk-rot-ctrl.h
@@ -39,6 +39,7 @@ struct _gtk_rot_ctrl {
 
     /* other widgets */
     GtkWidget      *SatSel;
+    GtkWidget      *SatSelFilter;
     GtkWidget      *SatCnt;
     GtkWidget      *DevSel;
     GtkWidget      *plot;       /*!< Polar plot widget */


### PR DESCRIPTION
When the count of satellites is big, it will be annoying to pick one from the combo box. A filter entry will be of some help.