### PR TITLE
Fix orbit number calculations.

### DIFF
--- a/src/gtk-sat-data.c
+++ b/src/gtk-sat-data.c
@@ -253,9 +253,10 @@ void gtk_sat_data_init_sat(sat_t * sat, qth_t * qth)
     sat->footprint = 2.0 * xkmper * acos(xkmper / sat->pos.w);
     age = 0.0;
     sat->orbit = (long)floor((sat->tle.xno * xmnpda / twopi +
-                              age * sat->tle.bstar * ae) * age -
-                             (sat->tle.xmo + sat->tle.omegao) / twopi) +
-        sat->tle.revnum;
+                              age * sat->tle.bstar * ae) * age +
+                             (sat->tle.xmo + sat->tle.omegao) / twopi)
+      - (long)floor((sat->tle.xmo + sat->tle.omegao) / twopi)
+      + sat->tle.revnum;
 
     /* orbit type */
     sat->otype = get_orbit_type(sat);

--- a/src/predict-tools.c
+++ b/src/predict-tools.c
@@ -105,7 +105,9 @@ void predict_calc(sat_t * sat, qth_t * qth, gdouble t)
     age = sat->jul_utc - sat->jul_epoch;
     sat->orbit = (long)floor((sat->tle.xno * xmnpda / twopi +
                               age * sat->tle.bstar * ae) * age +
-                             (sat->tle.xmo + sat->tle.omegao) / twopi) + sat->tle.revnum ;
+                             (sat->tle.xmo + sat->tle.omegao) / twopi)
+      - (long)floor((sat->tle.xmo + sat->tle.omegao) / twopi)
+      + sat->tle.revnum ;
 }
 
 /**


### PR DESCRIPTION
This solves two problems with the orbit number calculations:

- When age = 0, the orbit number must match the TLE revnum. However, the expression inside the floor(..) can be give a non-zero value. We need to subtract the result of the floor(..) with age = 0 to account for this.

- In gtk-sat-data.c, the sign of the term involving the argument of perigee and mean anomaly at epoch is wrong. The term should have a positive sign, since it counts as an increasing fraction of a revolution measured from the ascending node.