### PR TITLE
Desktop fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
-SUBDIRS = src doc pixmaps data po
+SUBDIRS = src doc icons pixmaps data po
 
 BUILT_SOURCES = $(top_srcdir)/.version
 $(top_srcdir)/.version:

--- a/configure.ac
+++ b/configure.ac
@@ -126,12 +126,14 @@ doc/man/Makefile
 src/Makefile
 src/sgpsdp/Makefile
 src/sgpsdp/TR/Makefile
+icons/Makefile
 pixmaps/Makefile
 pixmaps/maps/Makefile
 pixmaps/logos/Makefile
 pixmaps/icons/Makefile
 data/Makefile
 data/desktop/Makefile
+data/metainfo/Makefile
 data/satdata/Makefile
 po/Makefile.in
 ])

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = satdata desktop
+SUBDIRS = satdata desktop metainfo
 
 gpredict_datdir = $(pkgdatadir)/data
 

--- a/data/desktop/gpredict.desktop.in
+++ b/data/desktop/gpredict.desktop.in
@@ -2,7 +2,7 @@
 Name=Gpredict
 Comment=Satellite tracker
 Exec=gpredict
-Icon=gpredict-icon
+Icon=gpredict
 Terminal=false
 Type=Application
 Categories=HamRadio;Science;Astronomy;Education;Network;

--- a/data/metainfo/Makefile.am
+++ b/data/metainfo/Makefile.am
@@ -1,0 +1,5 @@
+gpredict_metainfodir = $(datadir)/metainfo
+
+gpredict_metainfo_DATA = dk.oz9aec.Gpredict.metainfo.xml
+
+EXTRA_DIST = $(gpredict_metainfo_DATA)

--- a/data/metainfo/dk.oz9aec.Gpredict.metainfo.xml
+++ b/data/metainfo/dk.oz9aec.Gpredict.metainfo.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>dk.oz9aec.Gpredict</id>
+  <name>Gpredict</name>
+  <developer_name>Alexandru Csete</developer_name>
+  <summary>Real-time satellite tracking and orbit prediction program</summary>
+  <description>
+    <p>Gpredict is a real time satellite tracking and orbit prediction program written using the Gtk+ widgets.</p>
+    <p>Gpredict is targeted mainly towards ham radio operators but others interested in satellite tracking may find it useful as well.</p>
+  </description>
+  <categories>
+    <category>Astronomy</category>
+    <category>Education</category>
+    <category>HamRadio</category>
+    <category>Network</category>
+    <category>Science</category>
+  </categories>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <provides>
+    <id>gpredict.desktop</id>
+  </provides>
+  <url type="homepage">https://oz9aec.dk/gpredict/</url>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://live.staticflickr.com/8089/28902144392_8cd36d57fe_b.jpg</image>
+    </screenshot>
+  </screenshots>
+  <launchable type="desktop-id">gpredict.desktop</launchable>
+  <content_rating type="oars-1.1" />
+</component>

--- a/data/satdata/Makefile.am
+++ b/data/satdata/Makefile.am
@@ -1,7 +1,5 @@
-
 gpredict_satdir = $(pkgdatadir)/data/satdata
 
 gpredict_sat_DATA = satellites.dat *.cat
 
 EXTRA_DIST = $(gpredict_sat_DATA)
-

--- a/icons/.gitignore
+++ b/icons/.gitignore
@@ -1,0 +1,2 @@
+Makefile
+Makefile.in

--- a/icons/Makefile.am
+++ b/icons/Makefile.am
@@ -1,0 +1,4 @@
+gpredict_iconsdir = $(datadir)/icons/hicolor/scalable/apps
+gpredict_icons_DATA = gpredict.svg
+
+EXTRA_DIST = $(gpredict_icons_DATA)

--- a/icons/gpredict.svg
+++ b/icons/gpredict.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="391.40039"
+   height="391.40039"
+   viewBox="0 0 103.55802 103.55802"
+   version="1.1"
+   id="svg6115"
+   inkscape:version="0.92.1 r"
+   sodipodi:docname="icon color.svg">
+  <defs
+     id="defs6109" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.7"
+     inkscape:cx="92.240312"
+     inkscape:cy="169.30629"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="1366"
+     inkscape:window-height="744"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata6112">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-106.21504,-94.786472)">
+    <g
+       id="g66"
+       transform="matrix(0.87883174,0,0,-0.87883174,209.77306,146.56548)">
+      <path
+         d="m 0,0 c 0,32.539 -26.378,58.918 -58.918,58.918 -32.539,0 -58.918,-26.379 -58.918,-58.918 0,-32.539 26.379,-58.918 58.918,-58.918 C -26.378,-58.918 0,-32.539 0,0"
+         style="fill:#00a69c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path68"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="g70"
+       transform="matrix(0.87883174,0,0,-0.87883174,132.21737,149.18861)">
+      <path
+         d="M 0,0 45.712,19.164 26.548,-26.548 20.938,-5.61 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path72"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="g74"
+       transform="matrix(0.87883174,0,0,-0.87883174,139.41017,113.02345)">
+      <path
+         d="m 0,0 -17.004,-17.004 15.889,-15.889 23.963,10.045 z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path76"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="g78"
+       transform="matrix(0.87883174,0,0,-0.87883174,191.71367,165.32695)">
+      <path
+         d="m 0,0 -17.004,-17.004 -15.889,15.889 10.045,23.963 z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path80"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/pixmaps/icons/Makefile.am
+++ b/pixmaps/icons/Makefile.am
@@ -1,9 +1,6 @@
-gpredict_iconsdir = $(datadir)/pixmaps/gpredict/icons
+gpredict_pixmaps_iconsdir = $(datadir)/pixmaps/gpredict/icons
 
-gpredict_icons2dir = $(datadir)/pixmaps/
-gpredict_icons2_DATA = gpredict-icon.png
-
-gpredict_icons_DATA = \
+gpredict_pixmaps_icons_DATA = \
 	gpredict-antenna.png \
 	gpredict-antenna-small.png \
 	gpredict-azel-small.png \
@@ -39,5 +36,4 @@ gpredict_icons_DATA = \
 	gpredict-shuttle.png \
 	gpredict-shuttle-small.png
 
-EXTRA_DIST = $(gpredict_icons_DATA) $(gpredict_icons2_DATA)
-
+EXTRA_DIST = $(gpredict_pixmaps_icons_DATA)

--- a/pixmaps/logos/Makefile.am
+++ b/pixmaps/logos/Makefile.am
@@ -1,6 +1,6 @@
-gpredict_logosdir = $(datadir)/pixmaps/gpredict/logos
+gpredict_pixmaps_logosdir = $(datadir)/pixmaps/gpredict/logos
 
-gpredict_logos_DATA = \
+gpredict_pixmaps_logos_DATA = \
     gpredict_horizontal_color.png \
     gpredict_horizontal_color.svg \
     gpredict_horizontal_white.png \
@@ -14,4 +14,4 @@ gpredict_logos_DATA = \
     gpredict_vertical_white.png \
     gpredict_vertical_white.svg
 
-EXTRA_DIST = $(gpredict_logos_DATA)
+EXTRA_DIST = $(gpredict_pixmaps_logos_DATA)

--- a/pixmaps/maps/Makefile.am
+++ b/pixmaps/maps/Makefile.am
@@ -1,7 +1,6 @@
+gpredict_pixmaps_mapsdir = $(datadir)/pixmaps/gpredict/maps
 
-gpredict_mapsdir = $(datadir)/pixmaps/gpredict/maps
-
-gpredict_maps_DATA = \
+gpredict_pixmaps_maps_DATA = \
     earth_800.png \
     nasa-bmng-01_1024.jpg \
     nasa-bmng-03_1024.jpg \
@@ -18,5 +17,4 @@ gpredict_maps_DATA = \
     nasa-topo_1600.jpg \
     nasa-topo_2048.jpg
 
-EXTRA_DIST = $(gpredict_maps_DATA)
-
+EXTRA_DIST = $(gpredict_pixmaps_maps_DATA)


### PR DESCRIPTION
- Add svg icon (from [here](https://github.com/csete/gpredict/blob/master/pixmaps/logos/gpredict_icon_color.svg)) installed into a standard icons dir instead of the non-standard dimensions png in pixmaps,
- Rename the desktop icon to just "gpredict" to match desktop file name,
- Add [AppStream](https://www.freedesktop.org/software/appstream/docs/) metainfo file,
- Fix Makefile formatting.

Closes #357.

Tested and works without issues.

/cc @csete