### PR TITLE
add iq capture commands for gqrx

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,3 @@
-
 Gpredict is a real time satellite tracking and orbit prediction program
 for the Linux desktop. It uses the SGP4/SDP4 propagation algorithms together
 with NORAD two-line element sets (TLE).
@@ -49,6 +48,7 @@ To build and install gpredict from source, first unpack the source package:
 
 Then change to the gpredict-x.y.z directory and build gpredict:
 
+  autoreconf -i
   ./configure
   make
   make install
@@ -61,6 +61,7 @@ adding --prefix=somedir to the ./configure step. For example
   ./configure --prefix=/home/user/predict
   
 will configure the build to install the files into /home/user/gpredict folder.
+Otherwise it will build to /usr/local/bin/gpredict.
 
 If you are building directly from the git repository, you have to run
 ./autogen.sh instead of of configure. You can pass the same options to the

--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -2393,6 +2393,20 @@ static gboolean check_aos_los(GtkRigCtrl * ctrl)
                                                     retbuf, 10);
                 }
             }
+            /* AOIQ has occurred */
+            if (ctrl->conf->signal_aoiq)
+            {
+                retcode &= send_rigctld_command(ctrl, ctrl->sock, "AOIQ\n",
+                                                retbuf, 10);
+            }
+            if (ctrl->conf2 != NULL)
+            {
+                if (ctrl->conf2->signal_aoiq)
+                {
+                    retcode &= send_rigctld_command(ctrl, ctrl->sock2, "AOIQ\n",
+                                                    retbuf, 10);
+                }
+            }
         }
         else if (ctrl->prev_ele >= 0.0 && ctrl->target->el < 0.0)
         {
@@ -2410,6 +2424,20 @@ static gboolean check_aos_los(GtkRigCtrl * ctrl)
                                                     retbuf, 10);
                 }
             }
+            /* LOIQ has occurred */
+            if (ctrl->conf->signal_loiq)
+            {
+                retcode &= send_rigctld_command(ctrl, ctrl->sock, "LOIQ\n",
+                                                retbuf, 10);
+            }
+            if (ctrl->conf2 != NULL)
+            {
+                if (ctrl->conf2->signal_loiq)
+                {
+                    retcode &= send_rigctld_command(ctrl, ctrl->sock2, "LOIQ\n",
+                                                    retbuf, 10);
+                }
+            }
         }
     }
 
@@ -2417,6 +2445,7 @@ static gboolean check_aos_los(GtkRigCtrl * ctrl)
 
     return retcode;
 }
+
 
 /*
  * Set frequency in simplex mode

--- a/src/radio-conf.c
+++ b/src/radio-conf.c
@@ -241,8 +241,6 @@ gboolean radio_conf_read(radio_conf_t * conf)
     conf->signal_aoiq = g_key_file_get_boolean(cfg, GROUP, KEY_SIG_AOIQ, NULL);
     conf->signal_loiq = g_key_file_get_boolean(cfg, GROUP, KEY_SIG_LOIQ, NULL);
 
-
-
     g_key_file_free(cfg);
     sat_log_log(SAT_LOG_LEVEL_INFO,
                 _("%s: Read radio configuration %s"), __func__, conf->name);
@@ -296,8 +294,6 @@ void radio_conf_save(radio_conf_t * conf)
     g_key_file_set_boolean(cfg, GROUP, KEY_SIG_LOS, conf->signal_los);
     g_key_file_set_boolean(cfg, GROUP, KEY_SIG_AOIQ, conf->signal_aoiq);
     g_key_file_set_boolean(cfg, GROUP, KEY_SIG_LOIQ, conf->signal_loiq);
-
-
 
     confdir = get_hwconf_dir();
     fname = g_strconcat(confdir, G_DIR_SEPARATOR_S, conf->name, ".rig", NULL);

--- a/src/radio-conf.c
+++ b/src/radio-conf.c
@@ -45,6 +45,8 @@
 #define KEY_VFO_UP      "VFO_UP"
 #define KEY_SIG_AOS     "SIGNAL_AOS"
 #define KEY_SIG_LOS     "SIGNAL_LOS"
+#define KEY_SIG_AOIQ    "SIGNAL_AOIQ"
+#define KEY_SIG_LOIQ    "SIGNAL_LOIQ"
 
 #define DEFAULT_CYCLE_MS    1000
 
@@ -236,6 +238,10 @@ gboolean radio_conf_read(radio_conf_t * conf)
     /* Signal AOS and LOS */
     conf->signal_aos = g_key_file_get_boolean(cfg, GROUP, KEY_SIG_AOS, NULL);
     conf->signal_los = g_key_file_get_boolean(cfg, GROUP, KEY_SIG_LOS, NULL);
+    conf->signal_aoiq = g_key_file_get_boolean(cfg, GROUP, KEY_SIG_AOIQ, NULL);
+    conf->signal_loiq = g_key_file_get_boolean(cfg, GROUP, KEY_SIG_LOIQ, NULL);
+
+
 
     g_key_file_free(cfg);
     sat_log_log(SAT_LOG_LEVEL_INFO,
@@ -288,6 +294,10 @@ void radio_conf_save(radio_conf_t * conf)
 
     g_key_file_set_boolean(cfg, GROUP, KEY_SIG_AOS, conf->signal_aos);
     g_key_file_set_boolean(cfg, GROUP, KEY_SIG_LOS, conf->signal_los);
+    g_key_file_set_boolean(cfg, GROUP, KEY_SIG_AOIQ, conf->signal_aoiq);
+    g_key_file_set_boolean(cfg, GROUP, KEY_SIG_LOIQ, conf->signal_loiq);
+
+
 
     confdir = get_hwconf_dir();
     fname = g_strconcat(confdir, G_DIR_SEPARATOR_S, conf->name, ".rig", NULL);

--- a/src/radio-conf.h
+++ b/src/radio-conf.h
@@ -70,8 +70,10 @@ typedef struct {
     vfo_t           vfoDown;    /*!< Downlink VFO for full-duplex radios */
     vfo_t           vfoUp;      /*!< Uplink VFO for full-duplex radios */
 
-    gboolean        signal_aos; /*!< Send AOS notification to RIG */
-    gboolean        signal_los; /*!< Send LOS notification to RIG */
+    gboolean        signal_aos;     /*!< Send AOS notification to RIG */
+    gboolean        signal_los;     /*!< Send LOS notification to RIG */
+    gboolean        signal_aoiq;    /*!< Send AOIQ notification to RIG */
+    gboolean        signal_loiq;    /*!< Send LOIQ notification to RIG */
 
     gint            vfo_opt;    /*!< Keep track of vfo_opt being enabled in rigctld */
 } radio_conf_t;

--- a/src/sat-pref-rig-data.h
+++ b/src/sat-pref-rig-data.h
@@ -40,6 +40,8 @@ typedef enum {
     RIG_LIST_COL_LOUP,          /*!< Local oscillato freq (uplink) */
     RIG_LIST_COL_SIGAOS,        /*!< Signal AOS */
     RIG_LIST_COL_SIGLOS,        /*!< Signal LOS */
+    RIG_LIST_COL_SIGAOIQ,       /*!< Signal AOIQ */
+    RIG_LIST_COL_SIGLOIQ,       /*!< Signal LOIQ */
     RIG_LIST_COL_NUM            /*!< The number of fields in the list. */
 } rig_list_col_t;
 

--- a/src/sat-pref-rig-editor.c
+++ b/src/sat-pref-rig-editor.c
@@ -43,6 +43,10 @@ static GtkWidget *lo;           /* local oscillator of downconverter */
 static GtkWidget *loup;         /* local oscillator of upconverter */
 static GtkWidget *sigaos;       /* AOS signalling */
 static GtkWidget *siglos;       /* LOS signalling */
+static GtkWidget *sigaoiq;      /* AOIQ signalling */
+static GtkWidget *sigloiq;      /* LOIQ signalling */
+
+
 
 
 static void clear_widgets()
@@ -58,6 +62,9 @@ static void clear_widgets()
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ptt), FALSE);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(sigaos), FALSE);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(siglos), FALSE);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(sigaoiq), FALSE);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(sigloiq), FALSE);
+
 }
 
 static void update_widgets(radio_conf_t * conf)
@@ -103,6 +110,8 @@ static void update_widgets(radio_conf_t * conf)
     /* AOS / LOS signalling */
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(sigaos), conf->signal_aos);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(siglos), conf->signal_los);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(sigaoiq), conf->signal_aoiq);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(sigloiq), conf->signal_loiq);
 }
 
 /*
@@ -436,6 +445,18 @@ static GtkWidget *create_editor_widgets(radio_conf_t * conf)
     gtk_widget_set_tooltip_text(siglos,
                                 _("Enable LOS signalling for this radio."));
 
+    sigaoiq = gtk_check_button_new_with_label(_("AOIQ"));
+    gtk_grid_attach(GTK_GRID(table), sigaoiq, 3, 8, 1, 1);
+    gtk_widget_set_tooltip_text(sigaoiq,
+                                _("Enable AOIQ signalling for this radio."));
+
+    sigloiq = gtk_check_button_new_with_label(_("LOIQ"));
+    gtk_grid_attach(GTK_GRID(table), sigloiq, 4, 8, 1, 1);
+    gtk_widget_set_tooltip_text(sigloiq,
+                                _("Enable LOIQ signalling for this radio."));
+
+
+
     if (conf->name != NULL)
         update_widgets(conf);
 
@@ -510,6 +531,9 @@ static gboolean apply_changes(radio_conf_t * conf)
     /* AOS / LOS signalling */
     conf->signal_aos = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(sigaos));
     conf->signal_los = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(siglos));
+    conf->signal_aoiq = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(sigaoiq));
+    conf->signal_loiq = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(sigloiq));
+
 
     return TRUE;
 }

--- a/src/sat-pref-rig.c
+++ b/src/sat-pref-rig.c
@@ -61,7 +61,9 @@ static GtkTreeModel *create_and_fill_model()
                                    G_TYPE_DOUBLE,       // LO DOWN
                                    G_TYPE_DOUBLE,       // LO UO
                                    G_TYPE_BOOLEAN,      // AOS signalling
-                                   G_TYPE_BOOLEAN       // LOS signalling
+                                   G_TYPE_BOOLEAN,      // LOS signalling
+                                   G_TYPE_BOOLEAN,      // AOIQ signalling
+                                   G_TYPE_BOOLEAN       // LOIQ signalling
         );
 
     gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(liststore),
@@ -98,6 +100,8 @@ static GtkTreeModel *create_and_fill_model()
                                        RIG_LIST_COL_LOUP, conf.loup,
                                        RIG_LIST_COL_SIGAOS, conf.signal_aos,
                                        RIG_LIST_COL_SIGLOS, conf.signal_los,
+                                       RIG_LIST_COL_SIGAOIQ, conf.signal_aoiq,
+                                       RIG_LIST_COL_SIGLOIQ, conf.signal_loiq,
                                        -1);
 
                     sat_log_log(SAT_LOG_LEVEL_DEBUG,
@@ -394,7 +398,9 @@ static void edit_cb(GtkWidget * button, gpointer data)
         .lo = 0.0,
         .loup = 0.0,
         .signal_aos = FALSE,
-        .signal_los = FALSE
+        .signal_los = FALSE,
+        .signal_aoiq = FALSE,
+        .signal_loiq = FALSE
     };
 
     /* If there are no entries, we have a bug since the button should 
@@ -426,7 +432,9 @@ static void edit_cb(GtkWidget * button, gpointer data)
                            RIG_LIST_COL_LO, &conf.lo,
                            RIG_LIST_COL_LOUP, &conf.loup,
                            RIG_LIST_COL_SIGAOS, &conf.signal_aos,
-                           RIG_LIST_COL_SIGLOS, &conf.signal_los, -1);
+                           RIG_LIST_COL_SIGLOS, &conf.signal_los, 
+                           RIG_LIST_COL_SIGAOIQ, &conf.signal_aoiq,
+                           RIG_LIST_COL_SIGLOIQ, &conf.signal_loiq,-1);
     }
     else
     {
@@ -462,7 +470,9 @@ static void edit_cb(GtkWidget * button, gpointer data)
                            RIG_LIST_COL_LO, conf.lo,
                            RIG_LIST_COL_LOUP, conf.loup,
                            RIG_LIST_COL_SIGAOS, conf.signal_aos,
-                           RIG_LIST_COL_SIGLOS, conf.signal_los, -1);
+                           RIG_LIST_COL_SIGLOS, conf.signal_los,
+                           RIG_LIST_COL_SIGAOIQ, conf.signal_aoiq,
+                           RIG_LIST_COL_SIGLOIQ, conf.signal_loiq, -1);
     }
 
     /* clean up memory */
@@ -611,6 +621,32 @@ static void create_rig_list()
 
     g_signal_connect(riglist, "row-activated", G_CALLBACK(row_activated_cb),
                      riglist);
+
+    /* AOIQ signalling */
+    renderer = gtk_cell_renderer_text_new();
+    column =
+        gtk_tree_view_column_new_with_attributes(_("Signal AOIQ"), renderer,
+                                                 "text", RIG_LIST_COL_SIGAOIQ,
+                                                 NULL);
+    gtk_tree_view_column_set_cell_data_func(column, renderer, render_signal,
+                                            GUINT_TO_POINTER
+                                            (RIG_LIST_COL_SIGAOIQ), NULL);
+    gtk_tree_view_insert_column(GTK_TREE_VIEW(riglist), column, -1);
+
+    /* LOIQ signalling */
+    renderer = gtk_cell_renderer_text_new();
+    column =
+        gtk_tree_view_column_new_with_attributes(_("Signal LOIQ"), renderer,
+                                                 "text", RIG_LIST_COL_SIGLOIQ,
+                                                 NULL);
+    gtk_tree_view_column_set_cell_data_func(column, renderer, render_signal,
+                                            GUINT_TO_POINTER
+                                            (RIG_LIST_COL_SIGLOIQ), NULL);
+    gtk_tree_view_insert_column(GTK_TREE_VIEW(riglist), column, -1);
+
+    g_signal_connect(riglist, "row-activated", G_CALLBACK(row_activated_cb),
+                     riglist);
+
 }
 
 /**
@@ -690,6 +726,8 @@ static void add_cb(GtkWidget * button, gpointer data)
         .loup = 0.0,
         .signal_aos = FALSE,
         .signal_los = FALSE,
+        .signal_aoiq = FALSE,
+        .signal_loiq = FALSE
     };
 
     /* run rig conf editor */
@@ -712,7 +750,9 @@ static void add_cb(GtkWidget * button, gpointer data)
                            RIG_LIST_COL_LO, conf.lo,
                            RIG_LIST_COL_LOUP, conf.loup,
                            RIG_LIST_COL_SIGAOS, conf.signal_aos,
-                           RIG_LIST_COL_SIGLOS, conf.signal_los, -1);
+                           RIG_LIST_COL_SIGLOS, conf.signal_los,
+                           RIG_LIST_COL_SIGAOIQ, conf.signal_aoiq,
+                           RIG_LIST_COL_SIGLOIQ, conf.signal_loiq, -1);
 
         g_free(conf.name);
 
@@ -813,7 +853,9 @@ void sat_pref_rig_ok()
         .lo = 0.0,
         .loup = 0.0,
         .signal_aos = FALSE,
-        .signal_los = FALSE
+        .signal_los = FALSE,
+        .signal_aoiq = FALSE,
+        .signal_loiq = FALSE
     };
 
     /* delete all .rig files */
@@ -859,7 +901,9 @@ void sat_pref_rig_ok()
                                RIG_LIST_COL_LO, &conf.lo,
                                RIG_LIST_COL_LOUP, &conf.loup,
                                RIG_LIST_COL_SIGAOS, &conf.signal_aos,
-                               RIG_LIST_COL_SIGLOS, &conf.signal_los, -1);
+                               RIG_LIST_COL_SIGLOS, &conf.signal_los,
+                               RIG_LIST_COL_SIGAOIQ, &conf.signal_aoiq,
+                               RIG_LIST_COL_SIGLOIQ, &conf.signal_loiq, -1);
             radio_conf_save(&conf);
 
             /* free conf buffer */


### PR DESCRIPTION
Related to a [request](https://github.com/gqrx-sdr/gqrx/issues/1403) on GQRX, I added logic for capturing the IQ part of the signal and not just the audio.

This was tested by connecting GQRX and gpredict, and confirming that when the AOIQ/LOIQ options were checked in the GUI, that an IQ file was produced.