### PR TITLE
README: fix dependencies

### DIFF
--- a/README
+++ b/README
@@ -39,7 +39,7 @@ If you compile Gpredict from source you will also need the development packages
 often with -dev or -devel in the package name, e.g. libgtk-3-dev. On Debian and
 Ubuntu systems you can install the build dependencies using:
 
-  sudo apt install libtool intltool autoconf automake libcurl4-openssl-dev
+  sudo apt install libtool intltool autoconf automake libcurl4-openssl-dev make
   sudo apt install pkg-config libglib2.0-dev libgtk-3-dev libgoocanvas-2.0-dev
 
 


### PR DESCRIPTION
Tested in Ubuntu 24. Fix err:
config.status: error: Something went wrong bootstrapping makefile fragments
    for automatic dependency tracking.  If GNU make was not used, consider
    re-running the configure script with MAKE="gmake" (or whatever is
    necessary).  You can also try re-running configure with the
    '--disable-dependency-tracking' option to at least be able to build
    the package (albeit without support for automatic dependency tracking).
See 'config.log' for more details