### PR TITLE
Add support for more recent gpsd API versions

### DIFF
--- a/src/qth-data.c
+++ b/src/qth-data.c
@@ -571,6 +571,8 @@ gboolean qth_data_update(qth_t * qth, gdouble t)
 	case 12:
 	case 13:
 	case 14:
+	case 15:
+	case 16: 
 #if GPSD_API_MAJOR_VERSION>=11          /* for libgps 3.22 or later */
             while (gps_waiting(qth->gps_data, 0) == 1)
             {
@@ -742,6 +744,8 @@ gboolean qth_data_update_init(qth_t * qth)
 	case 12:
 	case 13:
 	case 14:
+	case 15:
+	case 16:
 #if GPSD_API_MAJOR_VERSION>=11  /* for libgps 3.22 or later */
         /* open the connection to gpsd and start the stream */
         qth->gps_data = g_try_new0(struct gps_data_t, 1);
@@ -818,7 +822,9 @@ void qth_data_update_stop(qth_t * qth)
 	case 12:
 	case 13:
 	case 14:
-#if GPSD_API_MAJOR_VERSION==11
+	case 15:
+	case 16:
+#if GPSD_API_MAJOR_VERSION>=11
 	   gps_close(qth->gps_data);
 #endif
 	   break;


### PR DESCRIPTION
This pull request fixes support for more recent versions of gpsd. I was trying to use a small usb gps module with Gpredict and gpsd yesterday and it refused to work. Logs showed an unsupported API version(16). As far as I was able to determine there have been no significant or breaking changes to the API in a few versions, so just adding the recent version cases in with the most current #if shouldn't cause any issue. 

I have confirmed this change fixes the issue for me and I am able to get access to gpsd now.

As a side note, I've used this software for years and it's been a huge help. Big thanks to everyone keeping it going. 

-K4DBF

