### PR TITLE
Fix dual-device rig control: slot 2 never connects on Engage

### DIFF
--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -991,6 +991,7 @@ static void rig_engaged_cb(GtkToggleButton * button, gpointer data)
         /*  stop worker thread... */
         setconfig(ctrl);
         ctrl->rigctl_thread = NULL;
+        ctrl->conf2 = NULL;
     }
     else
     {
@@ -1003,7 +1004,6 @@ static void rig_engaged_cb(GtkToggleButton * button, gpointer data)
         ctrl->rigctl_thread = g_thread_new("rigctl_run", rigctl_run, ctrl);
         setconfig(ctrl);
     }
-    ctrl->conf2 = NULL;
 }
 
 static GtkWidget *create_target_widgets(GtkRigCtrl * ctrl)


### PR DESCRIPTION
# Fix: second-rig-not-connecting

## Bug

When two radio devices are configured (downlink + uplink), the second
device (slot 2) never receives a TCP connection after clicking Engage.

Only the first configured `rigctld` device connects successfully.

## Root cause

In `rig_engaged_cb()`, the following line was previously placed outside
the `if/else` block:

```c
ctrl->conf2 = NULL;
```

Original logic:

```c
ctrl->rigctl_thread = g_thread_new("rigctl_run", rigctl_run, ctrl);
setconfig(ctrl);
}
ctrl->conf2 = NULL;  /* runs on Engage AND Disengage */
}
```

This caused `ctrl->conf2` to be cleared unconditionally on every button
click — including Engage.

The worker thread checks:

```c
if (ctrl->conf2 != NULL)
```

before calling `open_rigctld_socket()` for the second device. By the
time the thread runs, the main thread has already cleared `conf2`, so
socket 2 is never opened.

## Fix

Move `ctrl->conf2 = NULL` inside the disengage branch only, where it
belongs.

Patch:

```diff
         ctrl->rigctl_thread = NULL;
+        ctrl->conf2 = NULL;
     }
     else
     {
         ctrl->rigctl_thread = g_thread_new("rigctl_run", rigctl_run, ctrl);
         setconfig(ctrl);
     }
-    ctrl->conf2 = NULL;
 }
```

Fixed behavior:

- Engage:
  - preserves `conf2`
  - worker thread can open both sockets
- Disengage:
  - clears `conf2` during shutdown as intended

No functional change to any other code path.

## Tested

Tested on:

- Ubuntu (x86_64)
- macOS Apple Silicon (ARM64)

Configuration:

- RX device:
  - GQRX
  - `rigctld` on TCP port `7356`

- TX device:
  - custom uplink module
  - `rigctld`-compatible server on TCP port `7358`

Results:

- Before fix:
  - only slot 1 connected on Engage
  - slot 2 never received a TCP connection

- After fix:
  - both devices connect simultaneously
  - RX and TX control work correctly