### PR TITLE
Fix/second rig not connecting

### DIFF
--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -991,6 +991,7 @@ static void rig_engaged_cb(GtkToggleButton * button, gpointer data)
         /*  stop worker thread... */
         setconfig(ctrl);
         ctrl->rigctl_thread = NULL;
+        ctrl->conf2 = NULL;
     }
     else
     {
@@ -1003,7 +1004,6 @@ static void rig_engaged_cb(GtkToggleButton * button, gpointer data)
         ctrl->rigctl_thread = g_thread_new("rigctl_run", rigctl_run, ctrl);
         setconfig(ctrl);
     }
-    ctrl->conf2 = NULL;
 }
 
 static GtkWidget *create_target_widgets(GtkRigCtrl * ctrl)

--- a/src/gtk-rig-ctrl.c
+++ b/src/gtk-rig-ctrl.c
@@ -988,10 +988,12 @@ static void rig_engaged_cb(GtkToggleButton * button, gpointer data)
         gtk_widget_set_sensitive(ctrl->DevSel2, TRUE);
         ctrl->engaged = FALSE;
 
-        /*  stop worker thread... */
+        /*  stop worker thread and wait for it to close sockets */
+        g_mutex_lock(&ctrl->widgetsync);
         setconfig(ctrl);
+        g_cond_wait(&ctrl->widgetready, &ctrl->widgetsync);
+        g_mutex_unlock(&ctrl->widgetsync);
         ctrl->rigctl_thread = NULL;
-        ctrl->conf2 = NULL;
     }
     else
     {
@@ -2860,7 +2862,7 @@ static void rigctrl_open(GtkRigCtrl * data)
     {
         open_rigctld_socket(ctrl->conf2, &(ctrl->sock2));
         /* set initial dual mode */
-        ctrl->conf2->vfo_opt = get_vfo_opt(ctrl, ctrl->sock);
+        ctrl->conf2->vfo_opt = get_vfo_opt(ctrl, ctrl->sock2);
         sat_log_log(SAT_LOG_LEVEL_DEBUG,
                 _("%s:%s: VFO opt2=%d"), __FILE__,
                 __func__, ctrl->conf2->vfo_opt);


### PR DESCRIPTION
# Fix: dual-rig engage/reconnect failures

## Bug

When two radio devices are configured (downlink + uplink), dual-rig
operation fails in two different ways.

### Failure 1 — second device never connects

On the first Engage, only slot 1 receives a TCP connection.

The second configured `rigctld` device (slot 2) never connects.

### Failure 2 — reconnect broken after disengage

After a successful Engage/Disengage cycle, any subsequent Engage fails.

Neither device reconnects correctly until Gpredict and all
`rigctld` instances are fully restarted.

## Root cause

Two independent issues existed in `rig_engaged_cb()` and the dual-rig
socket handling path.

### Root cause 1 — `conf2` cleared during Engage

The following line originally existed outside the `if/else` block:

```c
ctrl->conf2 = NULL;
```

Original logic:

```c
ctrl->rigctl_thread = g_thread_new("rigctl_run", rigctl_run, ctrl);
setconfig(ctrl);
}
ctrl->conf2 = NULL;  /* runs on Engage AND Disengage */
}
```

This caused `ctrl->conf2` to be cleared unconditionally on every button
click — including Engage.

The worker thread checks:

```c
if (ctrl->conf2 != NULL)
```

before calling `open_rigctld_socket()` for the second device.

By the time the worker thread runs, the main thread has already cleared
`conf2`, so socket 2 is never opened.

### Root cause 2 — unsynchronized shutdown and reconnect handling

The disengage branch originally had no synchronization with the worker
thread:

```c
ctrl->engaged = FALSE;
setconfig(ctrl);           /* pushes ctrl to queue — no wait */
ctrl->rigctl_thread = NULL;
ctrl->conf2 = NULL;
```

This caused two problems.

#### Problem 1 — sock2 never closed

`setconfig()` pushes `ctrl` into `ctrl->rigctlq` and returns
immediately.

The main thread then clears `conf2` before the worker thread can
process the queue and call `rigctrl_close()`.

`rigctrl_close()` checks:

```c
if (ctrl->conf2 != NULL)
    close_rigctld_socket(&(ctrl->sock2));
```

If `conf2` is already `NULL`, `sock2` is never closed.

The server-side TCP connection remains open and blocks future
connections.

#### Problem 2 — old worker thread still active

`ctrl->rigctl_thread = NULL` was assigned without waiting for the
worker thread to fully exit.

On the next Engage, a new thread is created while the previous thread
may still be running:

```c
ctrl->rigctlq = g_async_queue_new();   /* overwrites old queue */
ctrl->rigctl_thread = g_thread_new("rigctl_run", rigctl_run, ctrl);
```

Both threads now share:

- the same `ctrl`
- the same socket descriptors
- the same queue

This corrupts socket ownership and breaks reconnect behavior.

The correct synchronization pattern already existed in
`gtk_rig_ctrl_destroy()`, which uses `widgetsync` and `widgetready`
to wait for worker-thread shutdown before continuing.

The disengage path did not follow the same logic.

### Additional bug — wrong socket queried for VFO options

`rigctrl_open()` incorrectly queried `ctrl->sock` instead of
`ctrl->sock2` when determining `conf2->vfo_opt`.

Original code:

```c
ctrl->conf2->vfo_opt = get_vfo_opt(ctrl, ctrl->sock);
```

This caused slot 2 VFO capability detection to query the wrong device.

## Fix

### Fix 1 — preserve `conf2` during Engage

Remove the unconditional clear:

```diff
-    ctrl->conf2 = NULL;
```

`conf2` must remain valid during Engage so the worker thread can open
the second socket.

### Fix 2 — synchronized worker shutdown

Fix 2 supersedes the intermediate placement from Fix 1 —
`conf2` should be preserved across the full engage/disengage cycle,
not cleared at all.

Mirror the synchronization logic used by
`gtk_rig_ctrl_destroy()`.

Updated disengage path:

```diff
-        /*  stop worker thread... */
+        /*  stop worker thread and wait for it to close sockets */
+        g_mutex_lock(&ctrl->widgetsync);
         setconfig(ctrl);
+        g_cond_wait(&ctrl->widgetready, &ctrl->widgetsync);
+        g_mutex_unlock(&ctrl->widgetsync);
         ctrl->rigctl_thread = NULL;
-        ctrl->conf2 = NULL;
```

This guarantees:

- worker thread closes both sockets before shutdown continues
- no stale thread survives into the next Engage
- `conf2` remains valid across engage/disengage cycles

### Fix 3 — query correct socket for slot 2 VFO options

```diff
-        ctrl->conf2->vfo_opt = get_vfo_opt(ctrl, ctrl->sock);
+        ctrl->conf2->vfo_opt = get_vfo_opt(ctrl, ctrl->sock2);
```

## Fixed behavior

### Engage

- both socket connections open correctly
- slot 2 no longer disappears during startup
- both rigs initialize simultaneously

### Disengage

- worker thread fully closes sockets before shutdown completes
- no dangling TCP connections remain open
- no stale worker thread survives after disengage

### Re-engage

- new worker thread starts cleanly
- both devices reconnect successfully
- repeated engage/disengage cycles stable

No functional change to single-device configurations.

## Tested

Tested on:

- Ubuntu (x86_64)
- macOS Apple Silicon (ARM64)

Configuration:

- RX device:
  - GQRX
  - `rigctld` on TCP port `7356`

- TX device:
  - custom uplink program
  - `rigctld`-compatible server on TCP port `7358`

Results:

- Before fix:
  - slot 2 never connected on first Engage
  - Engage → Disengage → Engage failed consistently
  - required full restart of all programs to recover

- After fix:
  - both rigs connect correctly on first Engage
  - Engage → Disengage → Engage works reliably
  - repeated reconnect cycles stable
  - both devices reconnect simultaneously on every Engage