### PR TITLE
Add Alpha-5 catalog number support

### DIFF
--- a/src/sgpsdp/sgp_in.c
+++ b/src/sgpsdp/sgp_in.c
@@ -41,6 +41,37 @@
 #include <glib/gprintf.h>
 #include "sgp4sdp4.h"
 
+  /* from ChatGPT to allow ALPHA characters in Object ID's */
+
+static int
+decode_alpha5_catnr(const char field[5])
+{
+    static const char alpha5[] = "ABCDEFGHJKLMNPQRSTUVWXYZ";
+    const char *p;
+    int suffix;
+    int i;
+
+    for (i = 1; i < 5; i++)
+    {
+        if (field[i] < '0' || field[i] > '9')
+            return 0;
+    }
+
+    suffix = (field[1] - '0') * 1000 +
+             (field[2] - '0') * 100 +
+             (field[3] - '0') * 10 +
+             (field[4] - '0');
+
+    if (field[0] >= '0' && field[0] <= '9')
+        return (field[0] - '0') * 10000 + suffix;
+
+    p = strchr(alpha5, g_ascii_toupper(field[0]));
+    if (p == NULL)
+        return 0;
+
+    return (10 + (int)(p - alpha5)) * 10000 + suffix;
+}
+
 /* Calculates the checksum mod 10 of a line from a TLE set and */
 /* returns 1 if it compares with checksum in column 68, else 0.*/
 /* tle_set is a character string holding the two lines read    */
@@ -112,9 +143,14 @@ void Convert_Satellite_Data(char *tle_set, tle_t * tle)
     char            buff[15];
 
     /* Satellite's catalogue number */
+
+  /*
     strncpy(buff, &tle_set[2], 5);
     buff[5] = '\0';
     tle->catnr = atoi(buff);
+    */
+
+  tle->catnr = decode_alpha5_catnr(&tle_set[2]);
 
     /* International Designator for satellite */
     strncpy(tle->idesg, &tle_set[9], 8);
@@ -326,6 +362,7 @@ int Get_Next_Tle_Set(char line[3][80], tle_t * tle)
         return (-2);
 
     /* Convert the TLE set to orbital elements */
+
     Convert_Satellite_Data(tle_set, tle);
 
     return (1);

--- a/src/tle-update.c
+++ b/src/tle-update.c
@@ -45,6 +45,37 @@
 #include "sgpsdp/sgp4sdp4.h"
 #include "tle-update.h"
 
+/*  from ChatGPT to allow use of ALPHA characters in Object IDs */
+
+static guint
+decode_alpha5_catnr(const char field[5])
+{
+    static const char alpha5[] = "ABCDEFGHJKLMNPQRSTUVWXYZ";
+    const char *p;
+    guint suffix;
+    int i;
+
+    for (i = 1; i < 5; i++)
+    {
+        if (field[i] < '0' || field[i] > '9')
+            return 0;
+    }
+
+    suffix = (field[1] - '0') * 1000 +
+             (field[2] - '0') * 100 +
+             (field[3] - '0') * 10 +
+             (field[4] - '0');
+
+    if (field[0] >= '0' && field[0] <= '9')
+        return (field[0] - '0') * 10000 + suffix;
+
+    p = strchr(alpha5, g_ascii_toupper(field[0]));
+    if (p == NULL)
+        return 0;
+
+    return (10 + (guint)(p - alpha5)) * 10000 + suffix;
+}
+
 
 /* private function prototypes */
 #ifndef WIN32
@@ -998,7 +1029,12 @@ static gint read_fresh_tle(const gchar * dir, const gchar * fnam,
                 catstr[i - 2] = tle_str[1][i];
             }
             catstr[5] = '\0';
-            catnr = (guint) g_ascii_strtod(catstr, NULL);
+			
+            /* catnr = (guint) g_ascii_strtod(catstr, NULL); */
+
+			/*  from ChatGPT to allow use of ALPHA characters in Object IDs */
+
+			catnr = decode_alpha5_catnr(catstr);
 
 
             if (Get_Next_Tle_Set(tle_str, &tle) != 1)


### PR DESCRIPTION
CelesTrak's SATCAT crossed 100000 on 2026-07-11, so newly cataloged objects now use 6-digit numbers that don't fit the TLE format's 5-character catalog number field. Space-Track/CelesTrak's stopgap is Alpha-5 encoding, which replaces the leading digit with a letter (A-Z, excluding I/O) to represent numbers up to 339999.

Gpredict parses the catalog number field with a plain numeric conversion in two places (sgp_in.c's Convert_Satellite_Data and tle-update.c's read_fresh_tle), so any Alpha-5 catalog number silently decoded to 0. This adds an Alpha-5-aware decoder used in both spots, handling the legacy all-numeric format (zero- or space-padded) as well as Alpha-5.

Verified against Space-Track's published Alpha-5 test values (A0000->100000 ... Z9999->339999) plus legacy zero- and space-padded low catalog numbers.